### PR TITLE
fix(metrics): allow Prometheus to scrape actuator from monitoring con…

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/security/SecurityConfig.java
+++ b/src/main/java/beyou/beyouapp/backend/security/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                             "/auth/reset-password/**",
                             "/auth/verify-email"
                         ).permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/docs/admin/**").authenticated()
                         .requestMatchers("/docs/**").permitAll()
                         .anyRequest()

--- a/src/main/java/beyou/beyouapp/backend/security/SecurityFilter.java
+++ b/src/main/java/beyou/beyouapp/backend/security/SecurityFilter.java
@@ -48,7 +48,8 @@ public class SecurityFilter extends OncePerRequestFilter {
             requestURI.equals("/auth/forgot-password") ||
             requestURI.startsWith("/auth/reset-password") ||
             requestURI.equals("/auth/verify-email") ||
-            (requestURI.startsWith("/docs") && !requestURI.startsWith("/docs/admin"))
+            (requestURI.startsWith("/docs") && !requestURI.startsWith("/docs/admin")) ||
+            requestURI.startsWith("/actuator")
         ){
             filterChain.doFilter(request, response);
             return;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,7 +85,7 @@ docs:
 management:
   server:
     port: ${MANAGEMENT_PORT:9091}
-    address: 127.0.0.1
+    address: ${MANAGEMENT_ADDRESS:127.0.0.1}
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
…tainer

The recent hardening (BYU-INFO-02) bound management.server.address to 127.0.0.1 and left /actuator/** behind the JWT-authenticated chain, which broke scraping from the prometheus container (different network namespace, no Authorization header). Both barriers are addressed:

- application.yaml: address now resolves from ${MANAGEMENT_ADDRESS:127.0.0.1} so Docker can override to 0.0.0.0 while local non-Docker runs stay loopback.
- SecurityConfig: permitAll on /actuator/** so anyRequest().authenticated() does not block scrapes on the management port.
- SecurityFilter: bypass /actuator so the custom JWT filter does not return 401 for requests without an Authorization header.

Endpoint exposure is still restricted to health,metrics,prometheus.