### PR TITLE
fix: patch high-severity CVEs (Spring Boot 3.5.14, PostgreSQL 42.7.11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.11</version>
+		<version>3.5.14</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>beyou.beyouapp</groupId>
@@ -29,6 +29,8 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
+		<!-- Override Spring Boot 3.5.14 BOM (manages 42.7.10) to patch CVE-2026-42198 (CVSS 7.5) -->
+		<postgresql.version>42.7.11</postgresql.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
## Why

The OWASP `dependency-check` gate (`failBuildOnCVSS=7`) is failing CI on three dependencies:

| Dependency | Version | CVEs (CVSS ≥ 7.0) |
|---|---|---|
| `spring-boot` | 3.5.11 | CVE-2026-40974 (9.8), CVE-2026-40971 (9.1), CVE-2026-22731/22733 (8.1), CVE-2026-40972/40975 (7.5), CVE-2026-40973 (7.0) |
| `spring-security-core` | 6.5.8 | CVE-2026-22732 (9.1) |
| `postgresql` | 42.7.10 | CVE-2026-42198 (7.5) |

## What changed

Two lines in `pom.xml`:

1. **Spring Boot parent `3.5.11` → `3.5.14`** — clears all 7 `spring-boot` CVEs and transitively bumps `spring-security-core` to **6.5.10**.
2. **`<postgresql.version>42.7.11</postgresql.version>`** property override — the 3.5.14 BOM still pins PostgreSQL at the vulnerable `42.7.10`, so it must be overridden explicitly.

This is the **minimal, non-breaking** fix (stays within the `3.5.x` line). A Dependabot PR proposes the major `4.0.6` bump (Spring Framework 7 / Spring Security 7) — that's a larger migration and not required to clear these CVEs.

`log4j-api` 2.24.3 / CVE-2026-34479 (6.9) is **below** the 7.0 gate threshold and left unchanged.

## Verification

Every pinned version was checked against NVD's authoritative affected-version ranges:

| Dependency | Now | Fixed-in (NVD) | Clear |
|---|---|---|---|
| spring-boot | 3.5.14 | ≤ 3.5.14 | ✅ |
| spring-security-core | 6.5.10 | 6.5.9 | ✅ |
| postgresql | 42.7.11 | 42.7.11 | ✅ |

- `mvn dependency:tree` confirms resolved versions: `spring-boot 3.5.14`, `spring-security-core 6.5.10`, `postgresql 42.7.11`.
- `mvn test-compile` → **BUILD SUCCESS** (patch-level bumps, no source changes needed).

## Test plan

- [ ] CI `ci.yml` (build + tests) green
- [ ] CI `security-scan.yml` (OWASP Dependency-Check) green — the definitive confirmation, and the one residual check I couldn't run locally (would catch any *new* transitive CVE introduced by the bump, unlikely for a latest patch)
- [ ] CodeQL green
