### PR TITLE
fix: bump log4j2 to 2.25.4 to clear CVE-2026-34479 (OWASP gate)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
 		<java.version>25</java.version>
 		<!-- Override Spring Boot 3.5.14 BOM (manages 42.7.10) to patch CVE-2026-42198 (CVSS 7.5) -->
 		<postgresql.version>42.7.11</postgresql.version>
+		<!-- Override Spring Boot 3.5.14 BOM (manages 2.24.3) to patch CVE-2026-34479 (CVSS v3.1 7.5).
+		     Vulnerable code lives in the log4j-1.2-api bridge (Log4j1XmlLayout) + log4j-core,
+		     neither on our classpath (we only pull log4j-api + log4j-to-slf4j -> Logback),
+		     so this is a false positive; bumping past the fixed version (2.25.4) clears the gate. -->
+		<log4j2.version>2.25.4</log4j2.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
## Why

Follow-up to #33. With Spring Boot/Spring Security/PostgreSQL patched, the OWASP `dependency-check` gate (`failBuildOnCVSS=7`) still fails — now on a single finding:

```
log4j-api-2.24.3.jar : CVE-2026-34479
```

Two things to know:

1. **The "6.9" in the CI log is misleading.** The CVE carries two scores — CVSS **v4.0 = 6.9** (printed) and CVSS **v3.1 = 7.5** (HIGH). dependency-check evaluates the v3.1 score against the threshold, and `7.5 >= 7.0` fails the build. Not a misconfiguration.

2. **It's a false positive on `log4j-api`.** The vulnerable code is `Log4j1XmlLayout` / `org.apache.log4j.xml.XMLLayout`, which live in the **Log4j 1→2 bridge (`log4j-1.2-api`)** and require **`log4j-core`**. Our dependency tree has *neither* — only `log4j-to-slf4j` → `log4j-api` (interfaces only; all logging routes to Logback). NVD's `cpe:2.3:a:apache:log4j:*` CPE matches every 2.x artifact by version, so it tags `log4j-api` even though the vulnerable layout isn't in it.

## What changed

One line in `pom.xml`:

```xml
<log4j2.version>2.25.4</log4j2.version>
```

This overrides the Spring Boot 3.5.14 BOM (which pins `2.24.3`) and bumps `log4j-api` + `log4j-to-slf4j` in lockstep to **2.25.4** — the exact version the [advisory](https://logging.apache.org/log4j/2.x/) names as the fix (NVD range is `endExcluding 2.25.4`). I bumped rather than suppressed so the finding is genuinely remediated, not hidden.

## Verification

- `mvn dependency:tree` → `log4j-api:2.25.4`, `log4j-to-slf4j:2.25.4` (past the flagged `< 2.25.4` range).
- `mvn test-compile` → **BUILD SUCCESS** (2.24→2.25 is in-line, API-compatible; project is Java 25).

## Test plan

- [ ] CI `security-scan.yml` (OWASP Dependency-Check) green — should now report zero findings ≥ 7.0
- [ ] CI `ci.yml` (build + tests) green
- [ ] CodeQL green
