### PR TITLE
fix: profile re-fetch endpoint + duplicate-category crash

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/controllers/UserController.java
+++ b/src/main/java/beyou/beyouapp/backend/controllers/UserController.java
@@ -1,5 +1,6 @@
 package beyou.beyouapp.backend.controllers;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +22,12 @@ public class UserController {
     public UserController(UserService userService, AuthenticatedUser authenticatedUser){
         this.userService = userService;
         this.authenticatedUser = authenticatedUser;
+    }
+
+    @GetMapping()
+    public UserResponseDTO getProfile(){
+        User user = authenticatedUser.getAuthenticatedUser();
+        return userService.getProfile(user.getId());
     }
 
     @PutMapping()

--- a/src/main/java/beyou/beyouapp/backend/domain/goal/GoalMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/goal/GoalMapper.java
@@ -48,7 +48,10 @@ public class GoalMapper {
                         category -> new CategoryMiniDTO(
                             category.getName(),
                             category.getIconId()
-                        )
+                        ),
+                        // A goal may carry the same category twice (duplicate
+                        // join row); collapse instead of throwing on the key.
+                        (existing, duplicate) -> existing
                     ))
                 : Map.of();
 

--- a/src/main/java/beyou/beyouapp/backend/domain/goal/GoalService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/goal/GoalService.java
@@ -56,6 +56,7 @@ public class GoalService {
     public ResponseEntity<Map<String, String>> createGoal(CreateGoalRequestDTO dto, User user) {
         log.info("[LOG] Creating Goal with DTO => {}", dto);
         List<Category> categories = dto.categoriesId().stream()
+                .distinct()
                 .map(catId -> categoryService.getCategory(catId, user.getId()))
                 .toList();
 
@@ -74,6 +75,7 @@ public class GoalService {
         checkIfGoalIsFromTheUserInContext(goal, userId);
 
         List<Category> categories = dto.categoriesId().stream()
+                .distinct()
                 .map(catId -> categoryService.getCategory(catId, userId))
                 .toList();
         goalMapper.updateEntity(goal, dto, categories);

--- a/src/main/java/beyou/beyouapp/backend/domain/habit/HabitService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/habit/HabitService.java
@@ -76,10 +76,9 @@ public class HabitService {
         XpByLevel nextLevelXp = xpByLevelRepository.findByLevel(createHabitDTO.experience().getLevel() + 1);
 
         ArrayList<Category> categories = new ArrayList<>();
-        int numberOfCategories = createHabitDTO.categoriesId().size();
-        for(int i = 0; i < numberOfCategories; i++){
-            Category category = categoryService.getCategory(createHabitDTO.categoriesId().get(i), userId);
-            categories.add(category);
+        // Dedupe ids so a habit never gets the same category (and join row) twice.
+        for(UUID categoryId : createHabitDTO.categoriesId().stream().distinct().toList()){
+            categories.add(categoryService.getCategory(categoryId, userId));
         }
 
         Habit newHabit = habitMapper.toEntity(createHabitDTO, categories, actualBaseXp, nextLevelXp, user);
@@ -100,12 +99,11 @@ public class HabitService {
         }
 
         List<Category> categoriesEdit = new ArrayList<>();
-        int numberOfCategories = editHabitDTO.categoriesId().size();
-        for(int i = 0; i < numberOfCategories; i++){
-            Category category = categoryService.getCategory(editHabitDTO.categoriesId().get(i), userId);
-            categoriesEdit.add(category);
+        // Dedupe ids so a habit never gets the same category (and join row) twice.
+        for(UUID categoryId : editHabitDTO.categoriesId().stream().distinct().toList()){
+            categoriesEdit.add(categoryService.getCategory(categoryId, userId));
         }
-        
+
         habitMapper.updateEntity(habitToEdit, editHabitDTO, categoriesEdit);
         try{
             habitRepository.save(habitToEdit);

--- a/src/main/java/beyou/beyouapp/backend/domain/task/TaskMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/task/TaskMapper.java
@@ -41,11 +41,14 @@ public class TaskMapper {
             ?
             task.getCategories().stream()
                 .collect(Collectors.toMap(
-                    Category::getId, 
+                    Category::getId,
                     category -> new CategoryMiniDTO(
-                        category.getName(), 
+                        category.getName(),
                         category.getIconId()
-                    )
+                    ),
+                    // A task may carry the same category twice (duplicate join
+                    // row); collapse instead of throwing on the key.
+                    (existing, duplicate) -> existing
                 ))
             : Map.of();
 

--- a/src/main/java/beyou/beyouapp/backend/domain/task/TaskService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/task/TaskService.java
@@ -104,7 +104,8 @@ public class TaskService {
         List<Category> categoriesToAdd = new ArrayList<>();
 
         if(createTaskDTO.categoriesId() != null && !createTaskDTO.categoriesId().isEmpty()){
-            List<UUID> categoriesId = createTaskDTO.categoriesId();
+            // Dedupe ids so a task never gets the same category (and join row) twice.
+            List<UUID> categoriesId = createTaskDTO.categoriesId().stream().distinct().toList();
             categoriesId.forEach(categoryId ->
             categoriesToAdd.add(categoryService.getCategory(categoryId, userId)));
         }
@@ -136,7 +137,8 @@ public class TaskService {
         
         List<Category> categoriesToAdd = new ArrayList<>();
         if(editTaskRequestDTO.categoriesId() != null && !editTaskRequestDTO.categoriesId().isEmpty()){
-            List<UUID> categoriesId = editTaskRequestDTO.categoriesId();
+            // Dedupe ids so a task never gets the same category (and join row) twice.
+            List<UUID> categoriesId = editTaskRequestDTO.categoriesId().stream().distinct().toList();
             categoriesId.forEach(categoryId ->
             categoriesToAdd.add(categoryService.getCategory(categoryId, userId)));
         }

--- a/src/main/java/beyou/beyouapp/backend/user/UserService.java
+++ b/src/main/java/beyou/beyouapp/backend/user/UserService.java
@@ -150,6 +150,12 @@ public class UserService {
         }
     }
 
+    public UserResponseDTO getProfile(UUID userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFound("User not found by id"));
+        return userMapper.toResponseDTO(user);
+    }
+
     public UserResponseDTO editUser(UserEditDTO userEdit, UUID userId){
         Optional<User> userOpt = userRepository.findById(userId);
         if(userOpt.isPresent()){

--- a/src/test/java/beyou/beyouapp/backend/unit/goal/GoalMapperUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/goal/GoalMapperUnitTest.java
@@ -1,0 +1,53 @@
+package beyou.beyouapp.backend.unit.goal;
+
+import beyou.beyouapp.backend.domain.category.Category;
+import beyou.beyouapp.backend.domain.goal.Goal;
+import beyou.beyouapp.backend.domain.goal.GoalMapper;
+import beyou.beyouapp.backend.domain.goal.dto.GoalResponseDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproduces Bug 5: a goal associated with the SAME category more than once
+ * (a duplicate goal_category join row, which the {@code @ManyToMany List}
+ * allows) blew up {@code toResponseDTO} because {@code Collectors.toMap} throws
+ * {@code IllegalStateException: Duplicate key} on a repeated key.
+ *
+ * The duplicate originated from the UI sending the same id twice in
+ * {@code categoriesId}. The mapper must be resilient to it.
+ */
+public class GoalMapperUnitTest {
+
+    private Category category(UUID id, String name, String iconId) {
+        Category category = new Category();
+        category.setId(id);
+        category.setName(name);
+        category.setIconId(iconId);
+        return category;
+    }
+
+    @Test
+    void toResponseDTO_collapsesDuplicateCategoryAssociations() {
+        GoalMapper mapper = new GoalMapper();
+
+        UUID categoryId = UUID.randomUUID();
+        Category duplicated = category(categoryId, "Qualidade de Vida", "ri:md/MdOutlineFilterVintage");
+
+        Goal goal = new Goal();
+        goal.setId(UUID.randomUUID());
+        goal.setName("Regularizar-me em Portugal");
+        // Same category twice — exactly what the buggy create payload produced.
+        goal.setCategories(new ArrayList<>(List.of(duplicated, duplicated)));
+
+        GoalResponseDTO dto = mapper.toResponseDTO(goal);
+
+        assertEquals(1, dto.categories().size(),
+                "duplicate category associations must collapse to a single entry");
+        assertEquals("Qualidade de Vida", dto.categories().get(categoryId).name());
+    }
+}


### PR DESCRIPTION
## Summary
Backend fixes from a bug-fix session. Two user-facing bugs plus a carried-over dependency bump.

### Bug 1 — profile lost on page refresh
`GET /user` was missing, so the SPA had no way to re-hydrate the (non-persisted) `perfil` slice on boot — theme, tutorial-completed flag and language reverted on every reload. Added `GET /user` returning `UserResponseDTO` via the existing `UserMapper`.

### Bug 5 — "Duplicate key" crash creating/viewing a goal
A goal/task associated with the same category twice (a duplicate `(entity_id, category_id)` join row the `@ManyToMany List` allowed) crashed the mapper — `Collectors.toMap` throws `IllegalStateException` on a repeated key → 500/403 on `GET /goal`. Root cause: the UI sent the same id twice in `categoriesId`.
- Mappers (`GoalMapper`, `TaskMapper`): merge function on `toMap` → duplicates collapse instead of throwing.
- `GoalService` / `HabitService` / `TaskService`: `.distinct()` on `categoriesId` in create + edit → duplicate join rows never persisted.
- `GoalMapperUnitTest` reproduces the crash and locks in the fix.

### Also included
- `796d5b4` (pre-existing on this branch): bump log4j2 to 2.25.4 (CVE-2026-34479).

## Tests
- Backend unit suite: **143/143** green (incl. new `GoalMapperUnitTest`).
- Validated end-to-end via the frontend E2E profile-persistence suite.

## Notes
- Frontend counterpart (prevents duplicate `categoriesId` at the source) is a separate Beyou-Frontend PR.
- Follow-up (not in this PR): add `UNIQUE (entity_id, category_id)` on join tables as a DB-level guard.