### PR TITLE
fix(routine): delete removed sections on update (orphanRemoval)

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutine.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutine.java
@@ -23,7 +23,7 @@ import beyou.beyouapp.backend.domain.routine.Routine;
 @ToString
 public class DiaryRoutine extends Routine {
 
-    @OneToMany(mappedBy = "routine", cascade = CascadeType.ALL, orphanRemoval = false)
+    @OneToMany(mappedBy = "routine", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("orderIndex ASC")
     private List<RoutineSection> routineSections  = new ArrayList<>();
 }

--- a/src/test/java/beyou/beyouapp/backend/integration/routine/DiaryRoutineUpdateOrphanIT.java
+++ b/src/test/java/beyou/beyouapp/backend/integration/routine/DiaryRoutineUpdateOrphanIT.java
@@ -1,0 +1,102 @@
+package beyou.beyouapp.backend.integration.routine;
+
+import beyou.beyouapp.backend.AbstractIntegrationTest;
+import beyou.beyouapp.backend.domain.category.Category;
+import beyou.beyouapp.backend.domain.category.CategoryService;
+import beyou.beyouapp.backend.domain.category.dto.CategoryRequestDTO;
+import beyou.beyouapp.backend.domain.category.xpbylevel.XpByLevel;
+import beyou.beyouapp.backend.domain.category.xpbylevel.XpByLevelRepository;
+import beyou.beyouapp.backend.domain.common.ExperienceLevel;
+import beyou.beyouapp.backend.domain.habit.HabitRepository;
+import beyou.beyouapp.backend.domain.habit.HabitService;
+import beyou.beyouapp.backend.domain.habit.dto.CreateHabitDTO;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutine;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutineRepository;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutineService;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.DiaryRoutineRequestDTO;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.DiaryRoutineResponseDTO;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.HabitGroupDTO;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.RoutineSectionRequestDTO;
+import beyou.beyouapp.backend.user.User;
+import beyou.beyouapp.backend.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Removing a section on update must delete it, not leave it orphaned. */
+class DiaryRoutineUpdateOrphanIT extends AbstractIntegrationTest {
+
+    @Autowired private DiaryRoutineService diaryRoutineService;
+    @Autowired private DiaryRoutineRepository diaryRoutineRepository;
+    @Autowired private HabitRepository habitRepository;
+    @Autowired private CategoryService categoryService;
+    @Autowired private HabitService habitService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private XpByLevelRepository xpByLevelRepository;
+    @Autowired private TransactionTemplate transactionTemplate;
+
+    private User user;
+    private UUID habitId;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setName("Update Orphan IT User");
+        user.setEmail("update-orphan-" + UUID.randomUUID() + "@test.com");
+        user.setPassword("password123");
+        user = userRepository.saveAndFlush(user);
+        if (xpByLevelRepository.findByLevel(0) == null) xpByLevelRepository.save(new XpByLevel(0, 0));
+        if (xpByLevelRepository.findByLevel(1) == null) xpByLevelRepository.save(new XpByLevel(1, 100));
+
+        Category category = categoryService.createCategoryEntity(
+                new CategoryRequestDTO("Health", "ic", null, ExperienceLevel.BEGINNER), user);
+        habitId = habitService.createHabitEntity(
+                new CreateHabitDTO("Read", null, null, "ic", 3, 3, List.of(category.getId()),
+                        ExperienceLevel.BEGINNER),
+                user.getId()).getId();
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void updateRemovingPopulatedSectionDeletesItFromDb() {
+        RoutineSectionRequestDTO sectionA = new RoutineSectionRequestDTO(
+                null, "A", "ic", LocalTime.of(6, 0), LocalTime.of(7, 0),
+                List.of(),
+                List.of(new HabitGroupDTO(null, habitId, LocalTime.of(6, 0), LocalTime.of(6, 30), null)),
+                false);
+        RoutineSectionRequestDTO sectionB = new RoutineSectionRequestDTO(
+                null, "B", "ic", LocalTime.of(8, 0), LocalTime.of(9, 0), List.of(), List.of(), false);
+
+        DiaryRoutineResponseDTO created = diaryRoutineService.createDiaryRoutine(
+                new DiaryRoutineRequestDTO("R", "", List.of(sectionA, sectionB)), user);
+        assertEquals(2, created.routineSections().size());
+        UUID routineId = created.id();
+        UUID sectionBId = created.routineSections().stream()
+                .filter(s -> s.name().equals("B")).findFirst().orElseThrow().id();
+
+        RoutineSectionRequestDTO keepB = new RoutineSectionRequestDTO(
+                sectionBId, "B", "ic", LocalTime.of(8, 0), LocalTime.of(9, 0), List.of(), List.of(), false);
+        diaryRoutineService.updateDiaryRoutine(routineId,
+                new DiaryRoutineRequestDTO("R", "", List.of(keepB)), user.getId());
+
+        transactionTemplate.executeWithoutResult(tx -> {
+            DiaryRoutine routine = diaryRoutineRepository.findById(routineId).orElseThrow();
+            assertEquals(1, routine.getRoutineSections().size(),
+                    "removed section must be deleted, not orphaned");
+            assertEquals("B", routine.getRoutineSections().get(0).getName());
+        });
+
+        assertTrue(habitRepository.findById(habitId).isPresent(),
+                "habit survives — only its routine membership was deleted");
+    }
+}


### PR DESCRIPTION
## Bug

Editing a routine duplicated its sections. The `PUT /routine/{id}` response looked correct (the sections from the payload), but a subsequent `GET /routine` returned far more sections — duplicates plus orphan sections from earlier edits/AI generations that were no longer in the routine at all.

## Root cause

`DiaryRoutine.routineSections` was mapped with `orphanRemoval = false`:

```java
@OneToMany(mappedBy = "routine", cascade = CascadeType.ALL, orphanRemoval = false)
```

`DiaryRoutineService.mergeSections` updates a routine by pruning the in-memory collection (`routine.getRoutineSections().removeIf(...)`) and adding the incoming sections. Because the collection is the inverse side (`mappedBy = "routine"`) and `orphanRemoval` was off, a section removed from the collection **kept its `routine_id` FK and was never deleted** — so it reappeared on the next load. The PUT response reflected the pruned in-memory collection (correct), while GET did a fresh DB read and returned the accumulated orphans.

Pre-existing bug in the routine-update path; the AI "adjust with AI" flow exposed it dramatically because it replaces every section with a fresh id on each adjust, orphaning the whole previous set each time.

## Fix

`orphanRemoval = true` on `DiaryRoutine.routineSections`, matching the section's own children (`taskGroups` / `habitGroups` already use `orphanRemoval = true` with the same `removeIf` merge pattern). Removed sections are now DELETEd, cascading to their groups/checks; the referenced habits/tasks are untouched (only the routine membership is removed).

## Test

`DiaryRoutineUpdateOrphanIT` (Testcontainers): create a routine with a populated section A + empty section B, update keeping only B, then reload from the DB and assert exactly one section remains (A deleted, not orphaned) and the habit survives. Fails before the change (`expected: 1 but was: 2`), passes after. Full suite green (355).

## Existing data

This stops future accumulation; routines already carrying duplicate sections need a one-time cleanup — open the routine in the edit form, remove the duplicate sections, and save (deletion now works), or delete and recreate the routine.
