### PR TITLE
feat(auth): mobile refresh-token transport (X-Client / X-Refresh-Token)

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/controllers/AuthenticationController.java
+++ b/src/main/java/beyou/beyouapp/backend/controllers/AuthenticationController.java
@@ -34,8 +34,8 @@ public class AuthenticationController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Map<String, Object>> doLogin(HttpServletResponse response, @RequestBody @Valid UserLoginDTO userLoginDTO){
-        return userService.doLogin(response, userLoginDTO);
+    public ResponseEntity<Map<String, Object>> doLogin(HttpServletRequest request, HttpServletResponse response, @RequestBody @Valid UserLoginDTO userLoginDTO){
+        return userService.doLogin(request, response, userLoginDTO);
     }
 
     @PostMapping("/register")
@@ -50,8 +50,9 @@ public class AuthenticationController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<String> refreshAccess(HttpServletRequest request, HttpServletResponse response){
-        refreshTokenService.refreshAccessToken(request, response);
+    public ResponseEntity<?> refreshAccess(HttpServletRequest request, HttpServletResponse response){
+        String mobileRefresh = refreshTokenService.refreshAccessToken(request, response);
+        if (mobileRefresh != null) { return ResponseEntity.ok(Map.of("refreshToken", mobileRefresh)); }
         return ResponseEntity.ok("Access Token refreshed");
     }
 

--- a/src/main/java/beyou/beyouapp/backend/controllers/AuthenticationController.java
+++ b/src/main/java/beyou/beyouapp/backend/controllers/AuthenticationController.java
@@ -51,9 +51,9 @@ public class AuthenticationController {
 
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshAccess(HttpServletRequest request, HttpServletResponse response){
-        String mobileRefresh = refreshTokenService.refreshAccessToken(request, response);
-        if (mobileRefresh != null) { return ResponseEntity.ok(Map.of("refreshToken", mobileRefresh)); }
-        return ResponseEntity.ok("Access Token refreshed");
+        return refreshTokenService.refreshAccessToken(request, response)
+                .<ResponseEntity<?>>map(rt -> ResponseEntity.ok(Map.of("refreshToken", rt)))
+                .orElseGet(() -> ResponseEntity.ok("Access Token refreshed"));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/beyou/beyouapp/backend/security/ClientType.java
+++ b/src/main/java/beyou/beyouapp/backend/security/ClientType.java
@@ -1,0 +1,11 @@
+package beyou.beyouapp.backend.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class ClientType {
+    private ClientType() {}
+
+    public static boolean isMobile(HttpServletRequest request) {
+        return request != null && "mobile".equalsIgnoreCase(request.getHeader("X-Client"));
+    }
+}

--- a/src/main/java/beyou/beyouapp/backend/security/RefreshToken/RefreshTokenService.java
+++ b/src/main/java/beyou/beyouapp/backend/security/RefreshToken/RefreshTokenService.java
@@ -51,7 +51,7 @@ public class RefreshTokenService {
     }
 
     @Transactional
-    public String refreshAccessToken(HttpServletRequest request, HttpServletResponse response){
+    public Optional<String> refreshAccessToken(HttpServletRequest request, HttpServletResponse response){
         String cookieValue = recoverToken(request, true);
 
         String[] parts = cookieValue.split("\\.");
@@ -73,7 +73,7 @@ public class RefreshTokenService {
         String newToken = tokenService.generateJwtToken(refreshToken.getUser());
         String newRefreshToken = createRefreshToken(refreshToken.getUser());
         tokenService.addJwtTokenToResponse(response, newToken, newRefreshToken, mobile);
-        return mobile ? newRefreshToken : null;
+        return mobile ? Optional.of(newRefreshToken) : Optional.empty();
     }
 
     public void revokeRefreshToken(HttpServletRequest request, HttpServletResponse response){
@@ -130,20 +130,18 @@ public class RefreshTokenService {
     public String recoverToken(HttpServletRequest request, boolean throwIfNotFound){
         Optional<String> cookieToken = Optional.ofNullable(request.getCookies())
                 .flatMap(cookies -> Arrays.stream(cookies)
-                        .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                        .filter(c -> "refreshToken".equals(c.getName()))
                         .findFirst())
-                .map(Cookie::getValue);
+                .map(Cookie::getValue)
+                .filter(v -> v != null && !v.isBlank());
 
-        String token = cookieToken.orElseGet(() -> request.getHeader("X-Refresh-Token"));
+        String headerToken = request.getHeader("X-Refresh-Token");
+        String token = cookieToken.orElse((headerToken != null && !headerToken.isBlank()) ? headerToken : null);
 
-        if(throwIfNotFound){
-            if (token == null) {
-                throw new RefreshTokenNotFoundException("Refresh token not found in cookies or headers");
-            }
-            return token;
-        }else{
-            return token;
+        if (throwIfNotFound && token == null) {
+            throw new RefreshTokenNotFoundException("Refresh token not found in cookies or headers");
         }
+        return token;
     }
 
     private boolean isNotMatchingOrExpired(RefreshToken refreshToken, String rawToken, boolean throwIfExpired){

--- a/src/main/java/beyou/beyouapp/backend/security/RefreshToken/RefreshTokenService.java
+++ b/src/main/java/beyou/beyouapp/backend/security/RefreshToken/RefreshTokenService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import beyou.beyouapp.backend.exceptions.security.RefreshTokenDontMatchRaw;
 import beyou.beyouapp.backend.exceptions.security.RefreshTokenExpiredException;
 import beyou.beyouapp.backend.exceptions.security.RefreshTokenNotFoundException;
+import beyou.beyouapp.backend.security.ClientType;
 import beyou.beyouapp.backend.security.TokenService;
 import beyou.beyouapp.backend.user.User;
 import jakarta.servlet.http.Cookie;
@@ -50,7 +51,7 @@ public class RefreshTokenService {
     }
 
     @Transactional
-    public void refreshAccessToken(HttpServletRequest request, HttpServletResponse response){
+    public String refreshAccessToken(HttpServletRequest request, HttpServletResponse response){
         String cookieValue = recoverToken(request, true);
 
         String[] parts = cookieValue.split("\\.");
@@ -68,10 +69,11 @@ public class RefreshTokenService {
         refreshToken.setRevokedAt(Timestamp.from(Instant.now()));
         repository.save(refreshToken);
 
+        boolean mobile = ClientType.isMobile(request);
         String newToken = tokenService.generateJwtToken(refreshToken.getUser());
         String newRefreshToken = createRefreshToken(refreshToken.getUser());
-        tokenService.addJwtTokenToResponse(response, newToken, newRefreshToken);
-
+        tokenService.addJwtTokenToResponse(response, newToken, newRefreshToken, mobile);
+        return mobile ? newRefreshToken : null;
     }
 
     public void revokeRefreshToken(HttpServletRequest request, HttpServletResponse response){
@@ -126,16 +128,21 @@ public class RefreshTokenService {
     }
 
     public String recoverToken(HttpServletRequest request, boolean throwIfNotFound){
-        Optional<String> token = Optional.ofNullable(request.getCookies())
+        Optional<String> cookieToken = Optional.ofNullable(request.getCookies())
                 .flatMap(cookies -> Arrays.stream(cookies)
                         .filter(cookie -> "refreshToken".equals(cookie.getName()))
                         .findFirst())
                 .map(Cookie::getValue);
 
+        String token = cookieToken.orElseGet(() -> request.getHeader("X-Refresh-Token"));
+
         if(throwIfNotFound){
-            return token.orElseThrow(() -> new RefreshTokenNotFoundException("Refresh token not found in cookies"));
+            if (token == null) {
+                throw new RefreshTokenNotFoundException("Refresh token not found in cookies or headers");
+            }
+            return token;
         }else{
-            return token.orElse(null);
+            return token;
         }
     }
 

--- a/src/main/java/beyou/beyouapp/backend/security/TokenService.java
+++ b/src/main/java/beyou/beyouapp/backend/security/TokenService.java
@@ -60,13 +60,12 @@ public class TokenService {
         }
     }
 
-    public String addJwtTokenToResponse(HttpServletResponse response, String accessToken, String refreshToken, boolean mobile) {
+    public void addJwtTokenToResponse(HttpServletResponse response, String accessToken, String refreshToken, boolean mobile) {
         response.addHeader("X-Access-Token", accessToken);
         if (!mobile) {
             ResponseCookie cookie = buildRefreshCookie(refreshToken, Duration.ofDays(15));
             response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         }
-        return refreshToken;
     }
 
     public void addJwtTokenToResponse(HttpServletResponse response, String accessToken, String refreshToken) {

--- a/src/main/java/beyou/beyouapp/backend/security/TokenService.java
+++ b/src/main/java/beyou/beyouapp/backend/security/TokenService.java
@@ -60,11 +60,17 @@ public class TokenService {
         }
     }
 
-    public void addJwtTokenToResponse(HttpServletResponse response, String accessToken, String refreshToken){
+    public String addJwtTokenToResponse(HttpServletResponse response, String accessToken, String refreshToken, boolean mobile) {
         response.addHeader("X-Access-Token", accessToken);
+        if (!mobile) {
+            ResponseCookie cookie = buildRefreshCookie(refreshToken, Duration.ofDays(15));
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        }
+        return refreshToken;
+    }
 
-        ResponseCookie cookie = buildRefreshCookie(refreshToken, Duration.ofDays(15));
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    public void addJwtTokenToResponse(HttpServletResponse response, String accessToken, String refreshToken) {
+        addJwtTokenToResponse(response, accessToken, refreshToken, false);
     }
 
     public ResponseCookie buildRefreshCookie(String value, Duration maxAge) {

--- a/src/main/java/beyou/beyouapp/backend/user/UserService.java
+++ b/src/main/java/beyou/beyouapp/backend/user/UserService.java
@@ -3,12 +3,14 @@ package beyou.beyouapp.backend.user;
 import beyou.beyouapp.backend.exceptions.BusinessException;
 import beyou.beyouapp.backend.exceptions.ErrorKey;
 import beyou.beyouapp.backend.exceptions.user.UserNotFound;
+import beyou.beyouapp.backend.security.ClientType;
 import beyou.beyouapp.backend.security.TokenService;
 import beyou.beyouapp.backend.security.RefreshToken.RefreshTokenService;
 import beyou.beyouapp.backend.user.dto.UserEditDTO;
 import beyou.beyouapp.backend.user.dto.UserLoginDTO;
 import beyou.beyouapp.backend.user.dto.UserResponseDTO;
 import beyou.beyouapp.backend.user.event.UserRegisteredEvent;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.*;
 import lombok.RequiredArgsConstructor;
@@ -77,7 +79,7 @@ public class UserService {
             .orElseThrow(() -> new UserNotFound("User not found by id"));
     }
 
-    public ResponseEntity<Map<String, Object>> doLogin(HttpServletResponse response, UserLoginDTO userLoginDTO){
+    public ResponseEntity<Map<String, Object>> doLogin(HttpServletRequest request, HttpServletResponse response, UserLoginDTO userLoginDTO){
         Optional<User> loginUser = userRepository.findByEmail(userLoginDTO.email());
         if(loginUser.isPresent()){
             User user = loginUser.get();
@@ -86,11 +88,13 @@ public class UserService {
                     return ResponseEntity.status(HttpStatus.FORBIDDEN)
                             .body(Map.of("error", "EMAIL_NOT_VERIFIED"));
                 }
+                boolean mobile = ClientType.isMobile(request);
                 String accessToken = tokenService.generateJwtToken(user);
                 String refreshToken = refreshTokenService.createRefreshToken(user);
-
-                tokenService.addJwtTokenToResponse(response, accessToken, refreshToken);
-
+                tokenService.addJwtTokenToResponse(response, accessToken, refreshToken, mobile);
+                if (mobile) {
+                    return ResponseEntity.ok().body(Map.of("success", userMapper.toResponseDTO(user), "refreshToken", refreshToken));
+                }
                 return ResponseEntity.ok().body(Map.of("success", userMapper.toResponseDTO(user)));
             }
         }

--- a/src/test/java/beyou/beyouapp/backend/controller/AuthenticationControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/AuthenticationControllerTest.java
@@ -287,6 +287,47 @@ public class AuthenticationControllerTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.errorKey").value("PASSWORD_RESET_TOKEN_USED"));
     }
 
+    @Test
+    public void mobileLoginReturnsRefreshTokenInBodyAndNoCookie() throws Exception {
+        mockMvc.perform(post("/auth/login")
+                .header("X-Client", "mobile")
+                .content("{\"email\": \"testebeyou@gmail.com\", \"password\": \"TestPassword1!\"}")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("X-Access-Token"))
+                .andExpect(jsonPath("$.success.email").value("testebeyou@gmail.com"))
+                .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(cookie().doesNotExist("refreshToken"));
+    }
+
+    @Test
+    public void mobileRefreshAcceptsHeaderTokenAndReturnsNewTokenInBody() throws Exception {
+        MvcResult login = mockMvc.perform(post("/auth/login")
+                .header("X-Client", "mobile")
+                .content("{\"email\": \"testebeyou@gmail.com\", \"password\": \"TestPassword1!\"}")
+                .contentType(MediaType.APPLICATION_JSON)).andReturn();
+        String refresh = com.jayway.jsonpath.JsonPath.read(login.getResponse().getContentAsString(), "$.refreshToken");
+
+        mockMvc.perform(post("/auth/refresh").header("X-Client", "mobile").header("X-Refresh-Token", refresh))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("X-Access-Token"))
+                .andExpect(jsonPath("$.refreshToken").exists());
+    }
+
+    @Test
+    public void mobileLogoutRevokesHeaderToken() throws Exception {
+        MvcResult login = mockMvc.perform(post("/auth/login")
+                .header("X-Client", "mobile")
+                .content("{\"email\": \"testebeyou@gmail.com\", \"password\": \"TestPassword1!\"}")
+                .contentType(MediaType.APPLICATION_JSON)).andReturn();
+        String refresh = com.jayway.jsonpath.JsonPath.read(login.getResponse().getContentAsString(), "$.refreshToken");
+
+        mockMvc.perform(post("/auth/logout").header("X-Client", "mobile").header("X-Refresh-Token", refresh))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/auth/refresh").header("X-Client", "mobile").header("X-Refresh-Token", refresh))
+                .andExpect(status().isUnauthorized());
+    }
+
     private MvcResult simulateLogin() throws Exception {
         return mockMvc.perform(post("/auth/login")
                         .content("{\"email\": \"testebeyou@gmail.com\", \"password\": \"TestPassword1!\"}")

--- a/src/test/java/beyou/beyouapp/backend/unit/user/UserServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/user/UserServiceUnitTest.java
@@ -114,7 +114,7 @@ public class UserServiceUnitTest {
             when(passwordEncoder.matches(userLoginDTO.password(), user.getPassword())).thenReturn(true);
             when(tokenService.generateJwtToken(user)).thenReturn("mockedToken");
 
-            ResponseEntity<Map<String, Object>> loginResponse = userService.doLogin(response, userLoginDTO);
+            ResponseEntity<Map<String, Object>> loginResponse = userService.doLogin(null, response, userLoginDTO);
 
             UserResponseDTO userResponseDTO = userMapper.toResponseDTO(user);
 
@@ -459,7 +459,7 @@ public class UserServiceUnitTest {
 
             when(userRepository.findByEmail(userLoginDTO.email())).thenReturn(Optional.empty());
 
-            ResponseEntity<Map<String, Object>> loginResponse = userService.doLogin(response, userLoginDTO);
+            ResponseEntity<Map<String, Object>> loginResponse = userService.doLogin(null, response, userLoginDTO);
 
             assertEquals(ResponseEntity.status(HttpServletResponse.SC_UNAUTHORIZED)
                     .body(Map.of("error", "Email or password incorrect")), loginResponse);
@@ -474,7 +474,7 @@ public class UserServiceUnitTest {
             when(userRepository.findByEmail(userLoginDTO.email())).thenReturn(Optional.empty());
             when(passwordEncoder.matches(userLoginDTO.password(), user.getPassword())).thenReturn(false);
 
-            ResponseEntity<Map<String, Object>> loginResponse = userService.doLogin(response, userLoginDTO);
+            ResponseEntity<Map<String, Object>> loginResponse = userService.doLogin(null, response, userLoginDTO);
 
             assertEquals(ResponseEntity.status(HttpServletResponse.SC_UNAUTHORIZED)
                     .body(Map.of("error", "Email or password incorrect")), loginResponse);


### PR DESCRIPTION
## Summary

Phase 1 (mobile native auth) — **backend half**. Additive, web-safe change so a native mobile client can use the refresh-token flow without a browser cookie. **The web cookie path is 100% unchanged.**

A request is treated as mobile iff it carries the header `X-Client: mobile`. For mobile requests only:
- **Login / refresh** return the refresh token in the JSON body (`{ success, refreshToken }` / `{ refreshToken }`) and do **not** set the httpOnly cookie.
- **Refresh / logout** read the refresh token from the `X-Refresh-Token` request header (`recoverToken` reads cookie OR header, cookie precedence).

The access JWT continues to travel in the `X-Access-Token` response header (already mobile-readable). Token **rotation, bcrypt hashing, revocation, and 15-day expiry are unchanged** — only the transport (cookie vs body/header) is conditional.

## Changes
- `security/ClientType.java` (new) — `isMobile(request)`.
- `security/TokenService.java` — `addJwtTokenToResponse(..., boolean mobile)` (cookie only when !mobile) + back-compat overload.
- `user/UserService.java` — `doLogin` adds `refreshToken` to the body for mobile.
- `security/RefreshToken/RefreshTokenService.java` — `recoverToken` reads `X-Refresh-Token`; `refreshAccessToken` returns `Optional<String>` (mobile token).
- `controllers/AuthenticationController.java` — refresh returns the mobile body when present.

## Test plan
- [x] `mvn test` — **404/404 pass, 0 failures**.
- [x] 3 new `AuthenticationControllerTest` cases: mobile login (body refreshToken + no cookie), mobile refresh (X-Refresh-Token accepted, new token in body), mobile logout (revokes the header token).
- [x] Existing web cookie tests unchanged + green.
- [x] Independent cross-repo review: web security preserved, rotation/hash/revocation untouched.

## Note
Pairs with the frontend PR (`feat/mobile-phase1-native-auth` in Beyou-Frontend) which consumes these endpoints. Merge/deploy this first for the mobile auth flow to work end-to-end. Out of scope (later): Google OAuth on mobile, idempotency keys + client timestamps (Phase 3).