### PR TITLE
feat(auth): POST /auth/google/mobile for native Google sign-in

### DIFF
--- a/envExample
+++ b/envExample
@@ -7,6 +7,9 @@ DATABASE_PASSWORD=
 TOKEN_SECRET=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+# Allowed audiences for mobile Google ID tokens (comma-separated); defaults to GOOGLE_CLIENT_ID.
+# Add the Android/iOS OAuth client ids here once provisioned.
+GOOGLE_MOBILE_AUDIENCES=
 
 # URLs
 FRONTEND_URL=http://localhost:3000/

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,14 @@
 			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency>
 
+		<!-- Google ID token verification (mobile Google sign-in: verifies the ID token
+		     from expo-auth-session against Google's public keys; offline cert caching) -->
+		<dependency>
+			<groupId>com.google.api-client</groupId>
+			<artifactId>google-api-client</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/src/main/java/beyou/beyouapp/backend/controllers/AuthenticationController.java
+++ b/src/main/java/beyou/beyouapp/backend/controllers/AuthenticationController.java
@@ -5,6 +5,7 @@ import beyou.beyouapp.backend.security.passwordreset.PasswordResetService;
 import beyou.beyouapp.backend.user.UserService;
 import beyou.beyouapp.backend.user.UserServiceGoogleOAuth;
 import beyou.beyouapp.backend.user.dto.ForgotPasswordRequestDTO;
+import beyou.beyouapp.backend.user.dto.GoogleMobileLoginDTO;
 import beyou.beyouapp.backend.user.dto.UserLoginDTO;
 import beyou.beyouapp.backend.user.dto.UserRegisterDTO;
 import beyou.beyouapp.backend.user.dto.ResetPasswordRequestDTO;
@@ -47,6 +48,12 @@ public class AuthenticationController {
     public ResponseEntity<Map<String, Object>> googleAuth(@RequestParam("code") String code,
                                 HttpServletResponse response){
         return userServiceGoogleOAuth.googleAuth(code, response);
+    }
+
+    @PostMapping("/google/mobile")
+    public ResponseEntity<Map<String, Object>> googleMobileAuth(@RequestBody @Valid GoogleMobileLoginDTO request,
+                                HttpServletResponse response){
+        return userServiceGoogleOAuth.googleMobileAuth(request.idToken(), response);
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/beyou/beyouapp/backend/security/SecurityConfig.java
+++ b/src/main/java/beyou/beyouapp/backend/security/SecurityConfig.java
@@ -35,9 +35,10 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
-                            "/auth/login", 
-                            "/auth/register", 
+                            "/auth/login",
+                            "/auth/register",
                             "/auth/google",
+                            "/auth/google/mobile",
                             "/auth/refresh",
                             "/auth/logout",
                             "/auth/forgot-password",

--- a/src/main/java/beyou/beyouapp/backend/security/ratelimit/RateLimitFilter.java
+++ b/src/main/java/beyou/beyouapp/backend/security/ratelimit/RateLimitFilter.java
@@ -25,7 +25,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
     private final Cache<String, Bucket> rateLimitCache;
 
     private static final Set<String> AUTH_PATHS = Set.of(
-            "/auth/login", "/auth/register", "/auth/forgot-password"
+            "/auth/login", "/auth/register", "/auth/forgot-password", "/auth/google", "/auth/google/mobile"
     );
 
     private static final Set<String> WRITE_METHODS = Set.of("POST", "PUT", "DELETE", "PATCH");

--- a/src/main/java/beyou/beyouapp/backend/user/GoogleIdTokenVerifierService.java
+++ b/src/main/java/beyou/beyouapp/backend/user/GoogleIdTokenVerifierService.java
@@ -1,0 +1,19 @@
+package beyou.beyouapp.backend.user;
+
+import beyou.beyouapp.backend.user.dto.GoogleUserDTO;
+
+/**
+ * Verifies a Google-issued ID token (mobile sign-in) and returns the trusted
+ * profile claims. The seam keeps {@code UserServiceGoogleOAuth} testable and lets
+ * the e2e profile swap in a deterministic verifier with no real Google call.
+ */
+public interface GoogleIdTokenVerifierService {
+
+    /**
+     * @param idToken the raw Google ID token from the client
+     * @return the verified Google profile (email, name, picture)
+     * @throws beyou.beyouapp.backend.exceptions.BusinessException if the token is
+     *         invalid, expired, has the wrong audience, or the email is unverified
+     */
+    GoogleUserDTO verify(String idToken);
+}

--- a/src/main/java/beyou/beyouapp/backend/user/GoogleIdTokenVerifierServiceImpl.java
+++ b/src/main/java/beyou/beyouapp/backend/user/GoogleIdTokenVerifierServiceImpl.java
@@ -7,6 +7,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,7 @@ import java.util.List;
  * the token signature against Google's cached public keys plus the issuer, audience
  * and expiry in one call.
  */
+@Slf4j
 @Service
 public class GoogleIdTokenVerifierServiceImpl implements GoogleIdTokenVerifierService {
 
@@ -40,6 +42,10 @@ public class GoogleIdTokenVerifierServiceImpl implements GoogleIdTokenVerifierSe
         try {
             idToken = verifier.verify(idTokenString);
         } catch (Exception e) {
+            // An exception here (vs verify() returning null for a merely-invalid token)
+            // points at a misconfigured audience, clock skew, or a Google outage — surface
+            // the cause so it's diagnosable. Message only; never log the token itself.
+            log.warn("Google ID token verification errored: {}", e.getMessage());
             throw new BusinessException(ErrorKey.INVALID_REQUEST, "Invalid Google ID token");
         }
         if (idToken == null) {

--- a/src/main/java/beyou/beyouapp/backend/user/GoogleIdTokenVerifierServiceImpl.java
+++ b/src/main/java/beyou/beyouapp/backend/user/GoogleIdTokenVerifierServiceImpl.java
@@ -1,0 +1,59 @@
+package beyou.beyouapp.backend.user;
+
+import beyou.beyouapp.backend.exceptions.BusinessException;
+import beyou.beyouapp.backend.exceptions.ErrorKey;
+import beyou.beyouapp.backend.user.dto.GoogleUserDTO;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Real verifier backed by Google's {@link GoogleIdTokenVerifier}, which validates
+ * the token signature against Google's cached public keys plus the issuer, audience
+ * and expiry in one call.
+ */
+@Service
+public class GoogleIdTokenVerifierServiceImpl implements GoogleIdTokenVerifierService {
+
+    private final GoogleIdTokenVerifier verifier;
+
+    public GoogleIdTokenVerifierServiceImpl(@Value("${google.mobile.audiences}") String audiences) {
+        List<String> audienceList = Arrays.stream(audiences.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        // Built once; the verifier caches Google's public keys internally.
+        this.verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance())
+                .setAudience(audienceList)
+                .build();
+    }
+
+    @Override
+    public GoogleUserDTO verify(String idTokenString) {
+        GoogleIdToken idToken;
+        try {
+            idToken = verifier.verify(idTokenString);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorKey.INVALID_REQUEST, "Invalid Google ID token");
+        }
+        if (idToken == null) {
+            throw new BusinessException(ErrorKey.INVALID_REQUEST, "Invalid Google ID token");
+        }
+
+        GoogleIdToken.Payload payload = idToken.getPayload();
+        if (!Boolean.TRUE.equals(payload.getEmailVerified())) {
+            throw new BusinessException(ErrorKey.INVALID_REQUEST, "Google account email not verified");
+        }
+
+        String email = payload.getEmail();
+        String name = (String) payload.get("name");
+        String picture = (String) payload.get("picture");
+        return new GoogleUserDTO(email, name, picture);
+    }
+}

--- a/src/main/java/beyou/beyouapp/backend/user/UserServiceGoogleOAuth.java
+++ b/src/main/java/beyou/beyouapp/backend/user/UserServiceGoogleOAuth.java
@@ -28,6 +28,7 @@ public class UserServiceGoogleOAuth {
     private final RefreshTokenService refreshTokenService;
     private final UserRepository userRepository;
     private final UserMapper userMapper;
+    private final GoogleIdTokenVerifierService googleIdTokenVerifierService;
 
     @Value("${google.secrets.clientId}")
     String GOOGLE_CLIENT_ID;
@@ -70,6 +71,27 @@ public class UserServiceGoogleOAuth {
 
             return ResponseEntity.ok().body(Map.of("success",  userMapper.toResponseDTO(user)));
         }
+    }
+
+    /**
+     * Mobile Google sign-in: verifies the ID token (obtained on-device via
+     * expo-auth-session) server-side, then find-or-creates the user and issues the
+     * JWT + refresh token using the mobile contract (X-Access-Token header +
+     * refreshToken in the body, no cookie).
+     */
+    public ResponseEntity<Map<String, Object>> googleMobileAuth(String idToken, HttpServletResponse response) {
+        GoogleUserDTO googleUser = googleIdTokenVerifierService.verify(idToken);
+
+        User user = userRepository.findByEmail(googleUser.email())
+                .orElseGet(() -> userRepository.save(new User(googleUser)));
+
+        String jwtToken = tokenService.generateJwtToken(user);
+        String refreshToken = refreshTokenService.createRefreshToken(user);
+        tokenService.addJwtTokenToResponse(response, jwtToken, refreshToken, true);
+
+        return ResponseEntity.ok().body(Map.of(
+                "success", userMapper.toResponseDTO(user),
+                "refreshToken", refreshToken));
     }
 
     private String getOAuthAccessTokenGoogle(String code){

--- a/src/main/java/beyou/beyouapp/backend/user/dto/GoogleMobileLoginDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/user/dto/GoogleMobileLoginDTO.java
@@ -1,0 +1,10 @@
+package beyou.beyouapp.backend.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Mobile Google sign-in payload: the Google-issued ID token obtained on-device
+ * via expo-auth-session. Verified server-side against Google's public keys.
+ */
+public record GoogleMobileLoginDTO(@NotBlank String idToken) {
+}

--- a/src/main/resources/application-e2e.yml
+++ b/src/main/resources/application-e2e.yml
@@ -75,6 +75,8 @@ google:
   secrets:
     clientId: e2e-noop
     clientSecret: e2e-noop
+  mobile:
+    audiences: e2e-noop
   url:
     oauth: http://localhost/noop
     userInfo: http://localhost/noop

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -46,6 +46,8 @@ google:
   secrets:
     clientId: test
     clientSecret: test
+  mobile:
+    audiences: test
   url:
     oauth: test
     userInfo: test

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,6 +63,10 @@ google:
   secrets:
     clientId: ${GOOGLE_CLIENT_ID}
     clientSecret: ${GOOGLE_CLIENT_SECRET}
+  mobile:
+    # Allowed audiences for mobile Google ID tokens (comma-separated). Defaults to
+    # the web client id; add the Android/iOS client ids via GOOGLE_MOBILE_AUDIENCES.
+    audiences: ${GOOGLE_MOBILE_AUDIENCES:${GOOGLE_CLIENT_ID}}
   url:
     oauth: ${OAUTH_GOOGLE_URL}
     userInfo: ${USER_INFO_GOOGLE_URL}

--- a/src/test/java/beyou/beyouapp/backend/controller/AuthenticationControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/AuthenticationControllerTest.java
@@ -18,16 +18,22 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import beyou.beyouapp.backend.AbstractIntegrationTest;
+import beyou.beyouapp.backend.exceptions.BusinessException;
+import beyou.beyouapp.backend.exceptions.ErrorKey;
 import beyou.beyouapp.backend.notification.EmailService;
 import beyou.beyouapp.backend.security.passwordreset.PasswordResetToken;
 import beyou.beyouapp.backend.security.passwordreset.PasswordResetTokenRepository;
+import beyou.beyouapp.backend.user.GoogleIdTokenVerifierService;
 import beyou.beyouapp.backend.user.UserRepository;
 import beyou.beyouapp.backend.user.UserService;
 import beyou.beyouapp.backend.user.User;
+import beyou.beyouapp.backend.user.dto.GoogleUserDTO;
 import beyou.beyouapp.backend.user.dto.UserRegisterDTO;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -51,6 +57,10 @@ public class AuthenticationControllerTest extends AbstractIntegrationTest {
 
     @MockitoBean
     private EmailService emailService;
+
+    // Mocked so the mobile Google sign-in tests never make a real call to Google.
+    @MockitoBean
+    private GoogleIdTokenVerifierService googleIdTokenVerifierService;
 
     @BeforeEach
     void setup() {
@@ -326,6 +336,43 @@ public class AuthenticationControllerTest extends AbstractIntegrationTest {
                 .andExpect(status().isOk());
         mockMvc.perform(post("/auth/refresh").header("X-Client", "mobile").header("X-Refresh-Token", refresh))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void mobileGoogleSignInReturnsProfileAndRefreshTokenForValidIdToken() throws Exception {
+        when(googleIdTokenVerifierService.verify(anyString()))
+                .thenReturn(new GoogleUserDTO("googlemobile@gmail.com", "Google Mobile", "http://pic"));
+
+        mockMvc.perform(post("/auth/google/mobile")
+                .header("X-Client", "mobile")
+                .content("{\"idToken\": \"valid-id-token\"}")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("X-Access-Token"))
+                .andExpect(jsonPath("$.success.email").value("googlemobile@gmail.com"))
+                .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(cookie().doesNotExist("refreshToken"));
+    }
+
+    @Test
+    public void mobileGoogleSignInRejectsInvalidIdToken() throws Exception {
+        when(googleIdTokenVerifierService.verify(anyString()))
+                .thenThrow(new BusinessException(ErrorKey.INVALID_REQUEST, "Invalid Google ID token"));
+
+        mockMvc.perform(post("/auth/google/mobile")
+                .content("{\"idToken\": \"bad-token\"}")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorKey").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    public void mobileGoogleSignInRejectsBlankIdToken() throws Exception {
+        mockMvc.perform(post("/auth/google/mobile")
+                .content("{\"idToken\": \"\"}")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorKey").value("INVALID_REQUEST"));
     }
 
     private MvcResult simulateLogin() throws Exception {

--- a/src/test/java/beyou/beyouapp/backend/unit/user/UserServiceGoogleMobileAuthUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/user/UserServiceGoogleMobileAuthUnitTest.java
@@ -1,0 +1,122 @@
+package beyou.beyouapp.backend.unit.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import beyou.beyouapp.backend.exceptions.BusinessException;
+import beyou.beyouapp.backend.exceptions.ErrorKey;
+import beyou.beyouapp.backend.security.TokenService;
+import beyou.beyouapp.backend.security.RefreshToken.RefreshTokenService;
+import beyou.beyouapp.backend.user.GoogleIdTokenVerifierService;
+import beyou.beyouapp.backend.user.User;
+import beyou.beyouapp.backend.user.UserMapper;
+import beyou.beyouapp.backend.user.UserRepository;
+import beyou.beyouapp.backend.user.UserServiceGoogleOAuth;
+import beyou.beyouapp.backend.user.dto.GoogleUserDTO;
+import beyou.beyouapp.backend.user.dto.UserResponseDTO;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserServiceGoogleOAuth.googleMobileAuth")
+class UserServiceGoogleMobileAuthUnitTest {
+
+    @Mock private TokenService tokenService;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private UserRepository userRepository;
+    @Mock private UserMapper userMapper;
+    @Mock private GoogleIdTokenVerifierService googleIdTokenVerifierService;
+
+    private UserServiceGoogleOAuth service;
+    private MockHttpServletResponse response;
+
+    private static final String ID_TOKEN = "google-id-token";
+    private static final GoogleUserDTO GOOGLE_USER =
+            new GoogleUserDTO("alice@example.com", "Alice", "http://pic");
+
+    // UserResponseDTO is a final record (can't be mocked with the subclass mock-maker),
+    // so build a throwaway instance to stand in for the mapper output.
+    private static UserResponseDTO dummyDto() {
+        return new UserResponseDTO("Alice", "alice@example.com", null, null, 0, null, true,
+                List.of(), null, 0d, 0d, 0d, 0, null, false, 0, false, null, null, null);
+    }
+
+    @BeforeEach
+    void setUp() {
+        service = new UserServiceGoogleOAuth(tokenService, refreshTokenService, userRepository, userMapper,
+                googleIdTokenVerifierService);
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    @DisplayName("existing user: issues tokens with the mobile contract and returns the profile + refresh token")
+    void existingUser_returnsProfileAndRefreshTokenInBody() {
+        User user = new User(GOOGLE_USER);
+        UserResponseDTO dto = dummyDto();
+        when(googleIdTokenVerifierService.verify(ID_TOKEN)).thenReturn(GOOGLE_USER);
+        when(userRepository.findByEmail(GOOGLE_USER.email())).thenReturn(Optional.of(user));
+        when(tokenService.generateJwtToken(user)).thenReturn("jwt");
+        when(refreshTokenService.createRefreshToken(user)).thenReturn("refresh");
+        when(userMapper.toResponseDTO(user)).thenReturn(dto);
+
+        ResponseEntity<Map<String, Object>> result = service.googleMobileAuth(ID_TOKEN, response);
+
+        assertThat(result.getStatusCode().value()).isEqualTo(200);
+        assertThat(result.getBody()).containsEntry("success", dto).containsEntry("refreshToken", "refresh");
+        // mobile=true → refresh token rides in the body, not a cookie
+        verify(tokenService).addJwtTokenToResponse(response, "jwt", "refresh", true);
+        verify(userRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("new user: creates the account from the verified Google profile")
+    void newUser_createsAccount() {
+        when(googleIdTokenVerifierService.verify(ID_TOKEN)).thenReturn(GOOGLE_USER);
+        when(userRepository.findByEmail(GOOGLE_USER.email())).thenReturn(Optional.empty());
+        when(userRepository.save(org.mockito.ArgumentMatchers.any(User.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(tokenService.generateJwtToken(org.mockito.ArgumentMatchers.any(User.class))).thenReturn("jwt");
+        when(refreshTokenService.createRefreshToken(org.mockito.ArgumentMatchers.any(User.class))).thenReturn("refresh");
+        when(userMapper.toResponseDTO(org.mockito.ArgumentMatchers.any(User.class)))
+                .thenReturn(dummyDto());
+
+        ResponseEntity<Map<String, Object>> result = service.googleMobileAuth(ID_TOKEN, response);
+
+        ArgumentCaptor<User> saved = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(saved.capture());
+        assertThat(saved.getValue().getEmail()).isEqualTo(GOOGLE_USER.email());
+        assertThat(saved.getValue().isGoogleAccount()).isTrue();
+        assertThat(result.getBody()).containsEntry("refreshToken", "refresh");
+    }
+
+    @Test
+    @DisplayName("invalid token: propagates the verifier error and issues no tokens")
+    void invalidToken_propagatesAndIssuesNothing() {
+        when(googleIdTokenVerifierService.verify(ID_TOKEN))
+                .thenThrow(new BusinessException(ErrorKey.INVALID_REQUEST, "Invalid Google ID token"));
+
+        assertThatThrownBy(() -> service.googleMobileAuth(ID_TOKEN, response))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Invalid Google ID token");
+
+        verify(userRepository, never()).findByEmail(org.mockito.ArgumentMatchers.anyString());
+        verify(tokenService, never()).addJwtTokenToResponse(org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyBoolean());
+    }
+}


### PR DESCRIPTION
## What

Backend half of **D3** (Auth & Account batch) — the endpoint the mobile app calls after obtaining a Google **ID token** on-device via `expo-auth-session`. This is decoupled from the existing web `/auth/google` authorization-**code** flow, which is bound to the web `redirect_uri` + client secret and can't be reused from mobile.

## How it works
`POST /auth/google/mobile` `{ idToken }`:
1. **Verify** the ID token with Google's `GoogleIdTokenVerifier` (signature against Google's cached public keys, issuer, audience, expiry) and require a verified email.
2. **Find-or-create** the user from the verified profile (same path as the web Google flow).
3. **Issue** JWT + refresh using the mobile contract — `X-Access-Token` header + `refreshToken` in the body, no cookie (mirrors mobile `/auth/login`).

## Changes
- `GoogleIdTokenVerifierService` (+ impl) — verification behind an interface (a seam for unit tests and a future e2e swap). Allowed audiences from `google.mobile.audiences` (defaults to the web client id; add Android/iOS ids via `GOOGLE_MOBILE_AUDIENCES`).
- `UserServiceGoogleOAuth.googleMobileAuth(...)`, controller endpoint, `SecurityConfig` allowlist (`SecurityFilter` already covers it via `startsWith("/auth/google")`).
- `google.mobile.audiences` in all three profiles; `envExample` documents `GOOGLE_MOBILE_AUDIENCES`.
- `google-api-client:2.7.0` added (verifies fine on Java 25 / Boot 4.1).

## Security
Mirrors the established web Google flow. The ID token is Google's proof the caller controls that email, so linking to an existing same-email account is safe and consistent with `/auth/google`. Input validated (`@NotBlank`), errors generic (400 `INVALID_REQUEST`), no secrets logged.

## Tests
- 3 unit (`UserServiceGoogleMobileAuthUnitTest`): existing user, new user (account created), invalid token (propagates, issues nothing).
- 3 end-to-end (`AuthenticationControllerTest`, verifier `@MockitoBean`): valid → `success` profile + `refreshToken` + `X-Access-Token`, no cookie; invalid → 400; blank → 400.
- All green; full app context boots with the new bean across profiles.

## Follow-up
The mobile **"Continue with Google"** button (expo-auth-session → this endpoint) ships once the **Android OAuth client id** is provisioned. Spec: `docs/superpowers/specs/2026-06-27-mobile-auth-account-design.md`.

https://claude.ai/code/session_01LTqgyBhKozyFYBZ4jL5mKA