### PR TITLE
feat(snapshot): day-scoped endpoint to fetch all snapshots in one call

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/controllers/SnapshotController.java
+++ b/src/main/java/beyou/beyouapp/backend/controllers/SnapshotController.java
@@ -1,6 +1,7 @@
 package beyou.beyouapp.backend.controllers;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.format.annotation.DateTimeFormat;
@@ -34,6 +35,14 @@ public class SnapshotController {
     private final SnapshotService snapshotService;
     private final SnapshotCheckService snapshotCheckService;
     private final AuthenticatedUser authenticatedUser;
+
+    // All snapshots for one day in a single call (routes ahead of /routine/{id} — literal wins over path var).
+    @GetMapping("/snapshot")
+    public ResponseEntity<List<SnapshotResponseDTO>> getSnapshotsForDay(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        User user = authenticatedUser.getAuthenticatedUser();
+        return ResponseEntity.ok(snapshotService.getSnapshotsForDay(date, user.getId()));
+    }
 
     @GetMapping("/{routineId}/snapshot")
     public ResponseEntity<SnapshotResponseDTO> getSnapshot(

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/snapshot/RoutineSnapshotRepository.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/snapshot/RoutineSnapshotRepository.java
@@ -1,5 +1,6 @@
 package beyou.beyouapp.backend.domain.routine.snapshot;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +12,11 @@ import java.util.UUID;
 
 public interface RoutineSnapshotRepository extends JpaRepository<RoutineSnapshot, UUID> {
     Optional<RoutineSnapshot> findByRoutineIdAndSnapshotDate(UUID routineId, LocalDate snapshotDate);
+
+    // All of a user's snapshots for one day, in a single query. Backed by
+    // idx_snapshot_user_routine_date; @EntityGraph eager-loads checks to avoid N+1.
+    @EntityGraph(attributePaths = "checks")
+    List<RoutineSnapshot> findAllByUserIdAndSnapshotDate(UUID userId, LocalDate snapshotDate);
 
     @Query("SELECT rs.snapshotDate FROM RoutineSnapshot rs WHERE rs.routine.id = :routineId AND rs.snapshotDate BETWEEN :startDate AND :endDate ORDER BY rs.snapshotDate")
     List<LocalDate> findSnapshotDatesByRoutineIdAndMonth(@Param("routineId") UUID routineId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/snapshot/SnapshotService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/snapshot/SnapshotService.java
@@ -69,6 +69,13 @@ public class SnapshotService {
     }
 
     @Transactional(readOnly = true)
+    public List<SnapshotResponseDTO> getSnapshotsForDay(LocalDate date, UUID userId) {
+        return snapshotRepository.findAllByUserIdAndSnapshotDate(userId, date).stream()
+                .map(this::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
     public SnapshotMonthResponseDTO getSnapshotDatesForMonth(UUID routineId, String month, UUID userId) {
         DiaryRoutine routine = diaryRoutineRepository.findById(routineId)
                 .orElseThrow(() -> new BusinessException(ErrorKey.ROUTINE_NOT_FOUND,
@@ -96,6 +103,7 @@ public class SnapshotService {
 
         return new SnapshotResponseDTO(
                 snapshot.getId(),
+                snapshot.getRoutine().getId(),
                 snapshot.getSnapshotDate(),
                 snapshot.getRoutineName(),
                 snapshot.getRoutineIconId(),

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/snapshot/dto/SnapshotResponseDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/snapshot/dto/SnapshotResponseDTO.java
@@ -6,6 +6,6 @@ import java.util.List;
 import java.util.UUID;
 
 public record SnapshotResponseDTO(
-    UUID id, LocalDate snapshotDate, String routineName, String routineIconId,
+    UUID id, UUID routineId, LocalDate snapshotDate, String routineName, String routineIconId,
     boolean completed, @JsonRawValue String structure, List<SnapshotCheckResponseDTO> checks
 ) {}

--- a/src/test/java/beyou/beyouapp/backend/controller/SnapshotControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/SnapshotControllerTest.java
@@ -95,6 +95,7 @@ class SnapshotControllerTest extends AbstractIntegrationTest {
 
         SnapshotResponseDTO responseDTO = new SnapshotResponseDTO(
                 snapshotId,
+                routineId,
                 date,
                 "Morning Routine",
                 "sun-icon",
@@ -122,6 +123,7 @@ class SnapshotControllerTest extends AbstractIntegrationTest {
                         .param("date", "2025-03-15"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(snapshotId.toString()))
+                .andExpect(jsonPath("$.routineId").value(routineId.toString()))
                 .andExpect(jsonPath("$.snapshotDate").value("2025-03-15"))
                 .andExpect(jsonPath("$.routineName").value("Morning Routine"))
                 .andExpect(jsonPath("$.routineIconId").value("sun-icon"))
@@ -132,6 +134,33 @@ class SnapshotControllerTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.checks[0].itemName").value("Meditation"));
 
         verify(snapshotService).getSnapshot(routineId, date, userId);
+    }
+
+    @Test
+    void shouldGetSnapshotsForDay() throws Exception {
+        LocalDate date = LocalDate.of(2025, 3, 15);
+
+        SnapshotResponseDTO responseDTO = new SnapshotResponseDTO(
+                snapshotId,
+                routineId,
+                date,
+                "Morning Routine",
+                "sun-icon",
+                false,
+                "{\"sections\":[]}",
+                List.of());
+
+        when(snapshotService.getSnapshotsForDay(date, userId)).thenReturn(List.of(responseDTO));
+
+        mockMvc.perform(get("/routine/snapshot")
+                        .param("date", "2025-03-15"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(snapshotId.toString()))
+                .andExpect(jsonPath("$[0].routineId").value(routineId.toString()))
+                .andExpect(jsonPath("$[0].snapshotDate").value("2025-03-15"));
+
+        verify(snapshotService).getSnapshotsForDay(date, userId);
     }
 
     @Test

--- a/src/test/java/beyou/beyouapp/backend/integration/routine/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/beyou/beyouapp/backend/integration/routine/snapshot/SnapshotServiceTest.java
@@ -179,6 +179,7 @@ class SnapshotServiceTest {
 
         assertNotNull(result);
         assertEquals(snapshot.getId(), result.id());
+        assertEquals(routineId, result.routineId());
         assertEquals(snapshotDate, result.snapshotDate());
         assertEquals("Morning Routine", result.routineName());
         assertEquals("icon-morning", result.routineIconId());
@@ -213,6 +214,35 @@ class SnapshotServiceTest {
                 () -> snapshotService.getSnapshot(routineId, snapshotDate, userId));
 
         assertEquals(ErrorKey.SNAPSHOT_NOT_OWNED, exception.getErrorKey());
+    }
+
+    // ---------------------------------------------------------------
+    // getSnapshotsForDay tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void getSnapshotsForDay_returnsAllUserSnapshotsForDate() {
+        RoutineSnapshot snapshot = buildSnapshot(user);
+        when(snapshotRepository.findAllByUserIdAndSnapshotDate(userId, snapshotDate))
+                .thenReturn(List.of(snapshot));
+
+        List<SnapshotResponseDTO> result = snapshotService.getSnapshotsForDay(snapshotDate, userId);
+
+        assertEquals(1, result.size());
+        assertEquals(snapshot.getId(), result.get(0).id());
+        assertEquals(routineId, result.get(0).routineId());
+        verify(snapshotRepository).findAllByUserIdAndSnapshotDate(userId, snapshotDate);
+    }
+
+    @Test
+    void getSnapshotsForDay_returnsEmptyListWhenNoSnapshots() {
+        when(snapshotRepository.findAllByUserIdAndSnapshotDate(userId, snapshotDate))
+                .thenReturn(List.of());
+
+        List<SnapshotResponseDTO> result = snapshotService.getSnapshotsForDay(snapshotDate, userId);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
     }
 
     // ---------------------------------------------------------------
@@ -291,6 +321,7 @@ class SnapshotServiceTest {
         SnapshotResponseDTO result = snapshotService.toResponseDTO(snapshot);
 
         assertEquals(snapshot.getId(), result.id());
+        assertEquals(routineId, result.routineId());
         assertEquals(snapshotDate, result.snapshotDate());
         assertEquals("Morning Routine", result.routineName());
         assertEquals("icon-morning", result.routineIconId());


### PR DESCRIPTION
## Problem
The routines page (web + mobile) fetched **one `GET /routine/{id}/snapshot` per routine** (`Promise.all`) whenever the user opened a past day — N requests for N routines. There was no way to get a day's snapshots in a single call.

## Change
New endpoint: **`GET /api/v1/routine/snapshot?date=YYYY-MM-DD`** → returns all of the authenticated user's snapshots for that day in one query.

- `RoutineSnapshotRepository.findAllByUserIdAndSnapshotDate` with `@EntityGraph(checks)` to avoid N+1; backed by the existing `idx_snapshot_user_routine_date` index.
- `SnapshotService.getSnapshotsForDay` — ownership is inherent (query filters by `userId`), no post-fetch check needed.
- Added `routineId` to `SnapshotResponseDTO` so each snapshot self-identifies its routine (the frontend needs it to map snapshots back to routines; previously the web app relied on a fragile `routineName` match).
- Route `/routine/snapshot` sits ahead of `/routine/{id}` — literal wins over path variable (same mechanism as the existing `/routine/today`).

## Tests
- `SnapshotServiceTest`: `getSnapshotsForDay` returns all owned snapshots / empty list; `routineId` asserted in the mapper.
- `SnapshotControllerTest`: `shouldGetSnapshotsForDay` (routing + shape) and `routineId` in the per-routine response.
- Full run: `SnapshotServiceTest` + `SnapshotControllerTest` green.

## Notes
- Additive & backward compatible — the per-routine endpoint is unchanged (still used by the check/skip re-fetch).
- Frontend PR (Beyou-Frontend) consumes this; **merge this first**.