### PR TITLE
ci: e2e gate + GHCR publish (backend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-test:
     name: Build & Test
@@ -38,3 +42,103 @@ jobs:
           name: surefire-reports
           path: target/surefire-reports/
           retention-days: 7
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    timeout-minutes: 30
+    steps:
+      - name: Checkout backend (under test)
+        uses: actions/checkout@v6
+        with:
+          path: backend
+
+      - name: Checkout e2e tests
+        uses: actions/checkout@v6
+        with:
+          repository: AndDev741/Beyou-e2e-tests
+          ref: main
+          path: e2e
+
+      - name: Checkout dev-env
+        uses: actions/checkout@v6
+        with:
+          repository: AndDev741/Beyou-dev-env
+          ref: main
+          path: dev-env
+
+      - name: Checkout frontend (main, counterpart)
+        uses: actions/checkout@v6
+        with:
+          repository: AndDev741/Beyou-Frontend
+          ref: main
+          path: frontend
+
+      - name: Build backend image (under test)
+        run: docker build --target runtime -t beyou-backend:e2e ./backend
+
+      - name: Build web image (counterpart from main)
+        run: |
+          docker build --target nginx \
+            --build-arg VITE_API_URL=http://localhost:8099/api/v1 \
+            -t beyou-web:e2e -f ./frontend/apps/web/Dockerfile ./frontend
+
+      - name: Boot the stack
+        working-directory: dev-env
+        run: docker compose -f docker-compose.e2e.yml up -d --wait
+
+      - name: Wait for backend + web to serve
+        run: |
+          for i in $(seq 1 90); do curl -s -o /dev/null http://localhost:8099 && break; sleep 2; done
+          for i in $(seq 1 30); do curl -s -o /dev/null http://localhost:3000 && break; sleep 2; done
+
+      - name: Run Playwright
+        working-directory: e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+          BASE_URL=http://localhost:3000 npm test
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+
+      - name: Dump backend logs on failure
+        if: failure()
+        working-directory: dev-env
+        run: docker compose -f docker-compose.e2e.yml logs backend
+
+  publish:
+    name: Publish image
+    runs-on: ubuntu-latest
+    needs: [build-and-test, e2e]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runtime
+          push: true
+          tags: |
+            ghcr.io/anddev741/beyou-backend:latest
+            ghcr.io/anddev741/beyou-backend:sha-${{ env.SHORT_SHA }}


### PR DESCRIPTION
Adds to `ci.yml`:
- **`e2e` job** (`needs: build-and-test`): builds the backend image from this PR, builds web from `Beyou-Frontend@main`, boots `docker-compose.e2e.yml`, runs Playwright. Required check on backend PRs.
- **`publish` job** (`needs: [build-and-test, e2e]`, `main` only): pushes `ghcr.io/anddev741/beyou-backend:latest` + `:sha-<7>`.

**Merge order:** after **Beyou-dev-env#4** (e2e compose) **and** the Beyou-Frontend CI PR — this job builds web from `Beyou-Frontend@main`, so its e2e stays red until the frontend's Dockerfile-ARG change is on main.
After the first `main` run publishes the image, mark the **`beyou-backend`** GHCR package **Public**.