### PR TITLE
feat(sync): create endpoints accept optional client UUID for idempotent offline replay

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/domain/ai/AiRoutineConfirmService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/ai/AiRoutineConfirmService.java
@@ -80,7 +80,7 @@ public class AiRoutineConfirmService {
         Map<String, UUID> categoryIdByTempKey = new HashMap<>();
         for (DraftNewCategoryDTO newCategory : valid.newCategories()) {
             Category created = categoryService.createCategoryEntity(
-                    new CategoryRequestDTO(newCategory.name(), newCategory.icon(),
+                    new CategoryRequestDTO(null, newCategory.name(), newCategory.icon(),
                             newCategory.description(), ExperienceLevel.BEGINNER),
                     user);
             categoryIdByTempKey.put(newCategory.tempKey(), created.getId());
@@ -114,7 +114,7 @@ public class AiRoutineConfirmService {
         }
 
         // 3. the routine itself (existing validation + mapper + save)
-        DiaryRoutineRequestDTO requestDTO = new DiaryRoutineRequestDTO(valid.name(), valid.iconId(), sections);
+        DiaryRoutineRequestDTO requestDTO = new DiaryRoutineRequestDTO(null, valid.name(), valid.iconId(), sections);
         DiaryRoutineResponseDTO result;
         if (routineId == null) {
             result = diaryRoutineService.createDiaryRoutine(requestDTO, user);
@@ -149,7 +149,7 @@ public class AiRoutineConfirmService {
         List<UUID> newCategoryIds = new ArrayList<>();
         for (DraftNewCategoryDTO newCategory : valid.newCategories()) {
             Category created = categoryService.createCategoryEntity(
-                    new CategoryRequestDTO(newCategory.name(), newCategory.icon(),
+                    new CategoryRequestDTO(null, newCategory.name(), newCategory.icon(),
                             newCategory.description(), ExperienceLevel.BEGINNER),
                     user);
             categoryIdByTempKey.put(newCategory.tempKey(), created.getId());
@@ -199,13 +199,13 @@ public class AiRoutineConfirmService {
     }
 
     private CreateHabitDTO toCreateHabitDTO(DraftNewHabitDTO habit, Map<String, UUID> categoryIdByTempKey) {
-        return new CreateHabitDTO(habit.name(), habit.description(), habit.motivationalPhrase(),
+        return new CreateHabitDTO(null, habit.name(), habit.description(), habit.motivationalPhrase(),
                 habit.iconId(), habit.importance(), habit.dificulty(),
                 resolveCategoryRefs(habit.categoryRefs(), categoryIdByTempKey), ExperienceLevel.BEGINNER);
     }
 
     private CreateTaskRequestDTO toCreateTaskDTO(DraftNewTaskDTO task, Map<String, UUID> categoryIdByTempKey) {
-        return new CreateTaskRequestDTO(task.name(), task.description(), task.iconId(),
+        return new CreateTaskRequestDTO(null, task.name(), task.description(), task.iconId(),
                 task.importance(), task.difficulty(),
                 resolveCategoryRefs(task.categoryRefs(), categoryIdByTempKey), task.oneTimeTask());
     }

--- a/src/main/java/beyou/beyouapp/backend/domain/category/Category.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/category/Category.java
@@ -10,8 +10,10 @@ import beyou.beyouapp.backend.user.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import org.hibernate.annotations.BatchSize;
+import org.springframework.data.domain.Persistable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,7 +33,7 @@ import java.util.function.Function;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-public class Category {
+public class Category implements Persistable<UUID> {
      // No @GeneratedValue/@UuidGenerator: Hibernate 7.4's merge() throws
      // StaleObjectStateException when a manually-assigned id coexists with a
      // generator annotation on an entity that has never been persisted (the
@@ -43,6 +45,18 @@ public class Category {
      @Id
      @Column(updatable = false, nullable = false)
      private UUID id = UUID.randomUUID();
+
+     // Persistable.isNew() backing flag: defaults true for freshly-constructed
+     // (never-persisted) instances so save() calls entityManager.persist() —
+     // avoiding the merge()-triggered SELECT-then-INSERT "merge tax" on every
+     // create. @PostLoad/@PostPersist flip it false once Hibernate has seen the
+     // row, so update paths (which always load the managed entity first) keep
+     // going through merge()/dirty-checking. Excluded from Lombok's class-level
+     // @Getter/@Setter so the explicit isNew() override below doesn't collide.
+     @Transient
+     @Getter(AccessLevel.NONE)
+     @Setter(AccessLevel.NONE)
+     private boolean isNew = true;
 
      @NotBlank(message = "Category can't be empty")
      @Size(min = 2, max = 256, message = "Category need a minimum of 2 characters")
@@ -95,6 +109,17 @@ public class Category {
      protected void onUpdate(){
           LocalDate now = LocalDate.now();
           setUpdatedAt(Date.valueOf(now));
+     }
+
+     @PostLoad
+     @PostPersist
+     void markNotNew(){
+          this.isNew = false;
+     }
+
+     @Override
+     public boolean isNew(){
+          return this.isNew;
      }
 
      public Category(CategoryRequestDTO categoryRequestDTO, User user){

--- a/src/main/java/beyou/beyouapp/backend/domain/category/Category.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/category/Category.java
@@ -32,10 +32,17 @@ import java.util.function.Function;
 @NoArgsConstructor
 @ToString
 public class Category {
+     // No @GeneratedValue/@UuidGenerator: Hibernate 7.4's merge() throws
+     // StaleObjectStateException when a manually-assigned id coexists with a
+     // generator annotation on an entity that has never been persisted (the
+     // offline-sync replay path). Field-initializing the id keeps every other
+     // construction path working (AI materialize flow, seeds, tests) since the
+     // initializer runs on `new`, while letting mappers overwrite it with a
+     // client-supplied UUID when present. save() on a pre-set id goes through
+     // merge() (select-then-insert), and that select is the idempotency check.
      @Id
-     @GeneratedValue(strategy = GenerationType.UUID)
      @Column(updatable = false, nullable = false)
-     private UUID id;
+     private UUID id = UUID.randomUUID();
 
      @NotBlank(message = "Category can't be empty")
      @Size(min = 2, max = 256, message = "Category need a minimum of 2 characters")

--- a/src/main/java/beyou/beyouapp/backend/domain/category/CategoryMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/category/CategoryMapper.java
@@ -21,6 +21,9 @@ public class CategoryMapper {
 
     public Category toEntity(CategoryRequestDTO dto, User user, XpByLevel actualLevelXp, XpByLevel nextLevelXp) {
         Category category = new Category(dto, user);
+        if (dto.id() != null) {
+            category.setId(dto.id());
+        }
         XpProgress xpProgress = category.getXpProgress() != null ? category.getXpProgress() : new XpProgress();
         if (actualLevelXp != null) {
             xpProgress.setActualLevelXp(actualLevelXp.getXp());

--- a/src/main/java/beyou/beyouapp/backend/domain/category/CategoryService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/category/CategoryService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -65,6 +66,18 @@ public class CategoryService {
 
     /** Core create: saves and returns the entity. Does NOT evict caches — callers decide. */
     public Category createCategoryEntity(CategoryRequestDTO categoryRequestDTO, User user){
+        if (categoryRequestDTO.id() != null) {
+            Optional<Category> existing = categoryRepository.findById(categoryRequestDTO.id());
+            if (existing.isPresent()) {
+                if (!existing.get().getUser().getId().equals(user.getId())) {
+                    throw new BusinessException(ErrorKey.CATEGORY_NOT_OWNED, "This category does not belong to the user");
+                }
+                // Same user replaying a create (lost-response retry): true no-op —
+                // return the existing row untouched. This also keeps createdAt intact.
+                return existing.get();
+            }
+        }
+
         XpByLevel xpForNextLevel = xpByLevelRepository.findByLevel(categoryRequestDTO.experience().getLevel() + 1);
         XpByLevel xpForActualLevel = xpByLevelRepository.findByLevel(categoryRequestDTO.experience().getLevel());
 

--- a/src/main/java/beyou/beyouapp/backend/domain/category/dto/CategoryRequestDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/category/dto/CategoryRequestDTO.java
@@ -3,7 +3,10 @@ package beyou.beyouapp.backend.domain.category.dto;
 import beyou.beyouapp.backend.domain.common.ExperienceLevel;
 import jakarta.validation.constraints.*;
 
+import java.util.UUID;
+
 public record CategoryRequestDTO(
+        UUID id,
         @NotEmpty @Size(min = 2, max = 256) String name,
         @NotBlank String icon,
         String description,

--- a/src/main/java/beyou/beyouapp/backend/domain/goal/Goal.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/goal/Goal.java
@@ -18,11 +18,16 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.domain.Persistable;
 
 @Entity
 @Getter
@@ -30,7 +35,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 @Table(name = "goals")
-public class Goal {
+public class Goal implements Persistable<UUID> {
     // No @GeneratedValue: Hibernate 7.4's merge() throws StaleObjectStateException
     // when a manually-assigned id coexists with a generator annotation on an
     // entity that has never been persisted (the offline-sync replay path).
@@ -42,6 +47,18 @@ public class Goal {
     @Id
     @Column(updatable = false, nullable = false)
     private UUID id = UUID.randomUUID();
+
+    // Persistable.isNew() backing flag: defaults true for freshly-constructed
+    // (never-persisted) instances so save() calls entityManager.persist() —
+    // avoiding the merge()-triggered SELECT-then-INSERT "merge tax" on every
+    // create. @PostLoad/@PostPersist flip it false once Hibernate has seen the
+    // row, so update paths (which always load the managed entity first) keep
+    // going through merge()/dirty-checking. Excluded from Lombok's class-level
+    // @Getter/@Setter so the explicit isNew() override below doesn't collide.
+    @Transient
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private boolean isNew = true;
 
     @Column(nullable = false)
     private String name;
@@ -100,6 +117,17 @@ public class Goal {
     private GoalTerm term;
 
     private LocalDate completeDate;
+
+    @PostLoad
+    @PostPersist
+    void markNotNew(){
+        this.isNew = false;
+    }
+
+    @Override
+    public boolean isNew(){
+        return this.isNew;
+    }
 
     public Goal(CreateGoalRequestDTO dto, List<Category> categories, User user) {
         this.name = dto.name();

--- a/src/main/java/beyou/beyouapp/backend/domain/goal/Goal.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/goal/Goal.java
@@ -13,8 +13,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
@@ -33,10 +31,17 @@ import lombok.ToString;
 @ToString
 @Table(name = "goals")
 public class Goal {
+    // No @GeneratedValue: Hibernate 7.4's merge() throws StaleObjectStateException
+    // when a manually-assigned id coexists with a generator annotation on an
+    // entity that has never been persisted (the offline-sync replay path).
+    // Field-initializing the id keeps every other construction path working
+    // (AI materialize flow, seeds, tests) since the initializer runs on `new`,
+    // while letting the mapper overwrite it with a client-supplied UUID when
+    // present. save() on a pre-set id goes through merge() (select-then-insert),
+    // and that select is the idempotency check.
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(updatable = false, nullable = false)
-    private UUID id;
+    private UUID id = UUID.randomUUID();
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/beyou/beyouapp/backend/domain/goal/GoalMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/goal/GoalMapper.java
@@ -20,7 +20,11 @@ public class GoalMapper {
 
     public Goal toEntity(CreateGoalRequestDTO dto, List<Category> categories, User user) {
         List<Category> safeCategories = categories != null ? categories : Collections.emptyList();
-        return new Goal(dto, safeCategories, user);
+        Goal goal = new Goal(dto, safeCategories, user);
+        if (dto.id() != null) {
+            goal.setId(dto.id());
+        }
+        return goal;
     }
 
     public void updateEntity(Goal goal, EditGoalRequestDTO dto, List<Category> categories) {

--- a/src/main/java/beyou/beyouapp/backend/domain/goal/GoalService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/goal/GoalService.java
@@ -3,6 +3,7 @@ package beyou.beyouapp.backend.domain.goal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.cache.annotation.Cacheable;
@@ -55,6 +56,16 @@ public class GoalService {
 
     public ResponseEntity<Map<String, String>> createGoal(CreateGoalRequestDTO dto, User user) {
         log.info("[LOG] Creating Goal with DTO => {}", dto);
+        if (dto.id() != null) {
+            Optional<Goal> existing = goalRepository.findById(dto.id());
+            if (existing.isPresent()) {
+                checkIfGoalIsFromTheUserInContext(existing.get(), user.getId());
+                // Same user replaying a create (lost-response retry): true no-op —
+                // return the existing row untouched.
+                return ResponseEntity.ok(Map.of("success", "Goal created successfully"));
+            }
+        }
+
         List<Category> categories = dto.categoriesId().stream()
                 .distinct()
                 .map(catId -> categoryService.getCategory(catId, user.getId()))

--- a/src/main/java/beyou/beyouapp/backend/domain/goal/dto/CreateGoalRequestDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/goal/dto/CreateGoalRequestDTO.java
@@ -13,6 +13,7 @@ import beyou.beyouapp.backend.domain.goal.GoalStatus;
 import beyou.beyouapp.backend.domain.goal.GoalTerm;
 
 public record CreateGoalRequestDTO(
+    UUID id,
     @NotEmpty @Size(min = 2, max = 256)
     String name,
     String description,

--- a/src/main/java/beyou/beyouapp/backend/domain/habit/Habit.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/habit/Habit.java
@@ -25,15 +25,20 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.domain.Persistable;
 
 @Entity
 @Getter
@@ -42,7 +47,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-public class Habit {
+public class Habit implements Persistable<UUID> {
     // No @UuidGenerator: Hibernate 7.4's merge() throws StaleObjectStateException
     // when a manually-assigned id coexists with a generator annotation on an
     // entity that has never been persisted (the offline-sync replay path).
@@ -53,6 +58,18 @@ public class Habit {
     // and that select is the idempotency check.
     @Id
     private UUID id = UUID.randomUUID();
+
+    // Persistable.isNew() backing flag: defaults true for freshly-constructed
+    // (never-persisted) instances so save() calls entityManager.persist() —
+    // avoiding the merge()-triggered SELECT-then-INSERT "merge tax" on every
+    // create. @PostLoad/@PostPersist flip it false once Hibernate has seen the
+    // row, so update paths (which always load the managed entity first) keep
+    // going through merge()/dirty-checking. Excluded from Lombok's class-level
+    // @Getter/@Setter so the explicit isNew() override below doesn't collide.
+    @Transient
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private boolean isNew = true;
 
     @Column(nullable = false)
     @Size(min = 2, max = 256, message = "Name need a minimum of 2 characters")
@@ -121,6 +138,17 @@ public class Habit {
     @PreUpdate
     public void preUpdate(){
         setUpdatedAt(Date.valueOf(LocalDate.now()));
+    }
+
+    @PostLoad
+    @PostPersist
+    void markNotNew(){
+        this.isNew = false;
+    }
+
+    @Override
+    public boolean isNew(){
+        return this.isNew;
     }
 
     public Habit(CreateHabitDTO createHabitDTO, ArrayList<Category> categories, double nextLevelXp, double actualBaseXp, User user){

--- a/src/main/java/beyou/beyouapp/backend/domain/habit/Habit.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/habit/Habit.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.UuidGenerator;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -44,9 +43,16 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 public class Habit {
+    // No @UuidGenerator: Hibernate 7.4's merge() throws StaleObjectStateException
+    // when a manually-assigned id coexists with a generator annotation on an
+    // entity that has never been persisted (the offline-sync replay path).
+    // Field-initializing the id keeps every other construction path working
+    // (AI materialize flow, seeds, tests) since the initializer runs on `new`,
+    // while letting the mapper overwrite it with a client-supplied UUID when
+    // present. save() on a pre-set id goes through merge() (select-then-insert),
+    // and that select is the idempotency check.
     @Id
-    @UuidGenerator
-    private UUID id;
+    private UUID id = UUID.randomUUID();
 
     @Column(nullable = false)
     @Size(min = 2, max = 256, message = "Name need a minimum of 2 characters")
@@ -88,11 +94,16 @@ public class Habit {
     @Column(nullable = true)
     private int constance;
 
+    // Field-initialized (not just @PrePersist) for the same reason as `id` above:
+    // an offline-sync replay merges a freshly-built transient graph onto the
+    // already-persisted row, and @PrePersist never fires on that UPDATE path —
+    // a null default here would null out the NOT NULL created_at/updated_at
+    // columns during merge.
     @Column(nullable = false)
-    private Date createdAt;
+    private Date createdAt = Date.valueOf(LocalDate.now());
 
     @Column(nullable = false)
-    private Date updatedAt;
+    private Date updatedAt = Date.valueOf(LocalDate.now());
 
     @ManyToOne
     @JsonIgnore

--- a/src/main/java/beyou/beyouapp/backend/domain/habit/HabitMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/habit/HabitMapper.java
@@ -27,7 +27,11 @@ public class HabitMapper {
         List<Category> categoriesToUse = categories != null ? categories : Collections.emptyList();
         double nextXp = nextLevelXp != null ? nextLevelXp.getXp() : 0;
         double actualXp = actualBaseXp != null ? actualBaseXp.getXp() : 0;
-        return new Habit(dto, new ArrayList<>(categoriesToUse), nextXp, actualXp, user);
+        Habit habit = new Habit(dto, new ArrayList<>(categoriesToUse), nextXp, actualXp, user);
+        if (dto.id() != null) {
+            habit.setId(dto.id());
+        }
+        return habit;
     }
 
     public void updateEntity(Habit habit, EditHabitDTO dto, List<Category> categories) {

--- a/src/main/java/beyou/beyouapp/backend/domain/habit/HabitService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/habit/HabitService.java
@@ -3,6 +3,7 @@ package beyou.beyouapp.backend.domain.habit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,6 +71,18 @@ public class HabitService {
 
     /** Core create: saves and returns the entity. Does NOT evict caches — callers decide. */
     public Habit createHabitEntity(CreateHabitDTO createHabitDTO, UUID userId){
+        if (createHabitDTO.id() != null) {
+            Optional<Habit> existing = habitRepository.findById(createHabitDTO.id());
+            if (existing.isPresent()) {
+                if (!existing.get().getUser().getId().equals(userId)) {
+                    throw new BusinessException(ErrorKey.HABIT_NOT_OWNED, "The habit is not from the user in context");
+                }
+                // Same user replaying a create (lost-response retry): true no-op —
+                // return the existing row untouched. This also keeps createdAt intact.
+                return existing.get();
+            }
+        }
+
         User user = userRepository.findById(userId)
         .orElseThrow(() -> new UserNotFound("User not found"));
 

--- a/src/main/java/beyou/beyouapp/backend/domain/habit/dto/CreateHabitDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/habit/dto/CreateHabitDTO.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.UUID;
 
 public record CreateHabitDTO(
+        UUID id,
         @NotBlank(message = "Name is Required") @Size(min = 2, max = 256, message = "Name must be between 2 and 256 characters") String name,
         @Size(max = 1000, message = "Description is too long") String description,
         @Size(max = 500, message = "Motivational phrase is too long") String motivationalPhrase,

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/Routine.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/Routine.java
@@ -1,10 +1,12 @@
 package beyou.beyouapp.backend.domain.routine;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.domain.Persistable;
 
 import java.util.UUID;
 
@@ -22,7 +24,7 @@ import beyou.beyouapp.backend.user.User;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public abstract class Routine {
+public abstract class Routine implements Persistable<UUID> {
 
     // No @GeneratedValue: Hibernate 7.4's merge() throws StaleObjectStateException
     // when a manually-assigned id coexists with a generator annotation on an
@@ -34,6 +36,20 @@ public abstract class Routine {
     // and that select is the idempotency check.
     @Id
     private UUID id = UUID.randomUUID();
+
+    // Persistable.isNew() backing flag: defaults true for freshly-constructed
+    // (never-persisted) instances so save() calls entityManager.persist() —
+    // avoiding the merge()-triggered SELECT-then-INSERT "merge tax" on every
+    // create. @PostLoad/@PostPersist flip it false once Hibernate has seen the
+    // row, so update paths (which always load the managed entity first) keep
+    // going through merge()/dirty-checking. Excluded from Lombok's class-level
+    // @Getter/@Setter so the explicit isNew() override below doesn't collide.
+    // Declared on Routine (not DiaryRoutine) because this is where @Id lives —
+    // DiaryRoutine is the only Routine subtype today and inherits it.
+    @Transient
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private boolean isNew = true;
 
     @Column(nullable = false)
     private String name;
@@ -58,6 +74,17 @@ public abstract class Routine {
         getXpProgress().setNextLevelXp(0D);
         getXpProgress().setLevel(0);
         getXpProgress().setXp(0D);
+    }
+
+    @PostLoad
+    @PostPersist
+    void markNotNew(){
+        this.isNew = false;
+    }
+
+    @Override
+    public boolean isNew(){
+        return this.isNew;
     }
 
 }

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/Routine.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/Routine.java
@@ -24,9 +24,16 @@ import beyou.beyouapp.backend.user.User;
 @NoArgsConstructor
 public abstract class Routine {
 
+    // No @GeneratedValue: Hibernate 7.4's merge() throws StaleObjectStateException
+    // when a manually-assigned id coexists with a generator annotation on an
+    // entity that has never been persisted (the offline-sync replay path).
+    // Field-initializing the id keeps every other construction path working
+    // (AI materialize flow, seeds, tests) since the initializer runs on `new`,
+    // while letting the mapper overwrite it with a client-supplied UUID when
+    // present. save() on a pre-set id goes through merge() (select-then-insert),
+    // and that select is the idempotency check.
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    private UUID id = UUID.randomUUID();
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/checks/CheckItemService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/checks/CheckItemService.java
@@ -44,7 +44,7 @@ public class CheckItemService {
 
     @Transactional
     public RefreshUiDTO checkOrUncheckItemGroup(CheckGroupRequestDTO checkGroupDTO) {
-        LocalDate date = LocalDate.now();
+        LocalDate date = checkGroupDTO.date() != null ? checkGroupDTO.date() : LocalDate.now();
         if(checkGroupDTO.habitGroupDTO() != null){
             HabitGroup habitGroup = itemGroupService.findHabitGroupByDTO(checkGroupDTO.routineId(), checkGroupDTO.habitGroupDTO().habitGroupId());
             return checkOrUncheckHabitGroup(habitGroup, date);

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutineMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutineMapper.java
@@ -35,6 +35,9 @@ public class DiaryRoutineMapper {
 
     public DiaryRoutine toEntity(DiaryRoutineRequestDTO dto) {
         DiaryRoutine diaryRoutine = new DiaryRoutine();
+        if (dto.id() != null) {
+            diaryRoutine.setId(dto.id());
+        }
         diaryRoutine.setName(dto.name());
         diaryRoutine.setIconId(dto.iconId());
         diaryRoutine.setRoutineSections(mapToRoutineSections(dto.routineSections(), diaryRoutine));

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutineService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutineService.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -108,6 +109,20 @@ public class DiaryRoutineService {
     @Transactional
     public DiaryRoutineResponseDTO createDiaryRoutine(DiaryRoutineRequestDTO dto, User user) {
         validateRequestDTO(dto);
+
+        if (dto.id() != null) {
+            Optional<DiaryRoutine> existing = diaryRoutineRepository.findById(dto.id());
+            if (existing.isPresent()) {
+                if (!existing.get().getUser().getId().equals(user.getId())) {
+                    throw new BusinessException(ErrorKey.ROUTINE_NOT_OWNED,
+                            "The user trying to get its different of the one in the object");
+                }
+                // Same user replaying a create (lost-response retry): true no-op —
+                // return the existing row untouched.
+                return mapper.toResponse(existing.get());
+            }
+        }
+
         DiaryRoutine diaryRoutine = mapper.toEntity(dto);
         diaryRoutine.setUser(user);
         DiaryRoutine saved = diaryRoutineRepository.save(diaryRoutine);

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/dto/DiaryRoutineRequestDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/dto/DiaryRoutineRequestDTO.java
@@ -1,7 +1,8 @@
 package beyou.beyouapp.backend.domain.routine.specializedRoutines.dto;
 
 import java.util.List;
+import java.util.UUID;
 
-public record DiaryRoutineRequestDTO(String name, String iconId, List<RoutineSectionRequestDTO> routineSections) {
-    
+public record DiaryRoutineRequestDTO(UUID id, String name, String iconId, List<RoutineSectionRequestDTO> routineSections) {
+
 }

--- a/src/main/java/beyou/beyouapp/backend/domain/task/Task.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/task/Task.java
@@ -18,13 +18,18 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.domain.Persistable;
 
 @Entity
 @Getter
@@ -32,7 +37,7 @@ import lombok.ToString;
 @Table(name = "tasks")
 @NoArgsConstructor
 @ToString
-public class Task {
+public class Task implements Persistable<UUID> {
     // No @GeneratedValue: Hibernate 7.4's merge() throws StaleObjectStateException
     // when a manually-assigned id coexists with a generator annotation on an
     // entity that has never been persisted (the offline-sync replay path).
@@ -44,6 +49,18 @@ public class Task {
     @Id
     @Column(updatable = false, nullable = false)
     UUID id = UUID.randomUUID();
+
+    // Persistable.isNew() backing flag: defaults true for freshly-constructed
+    // (never-persisted) instances so save() calls entityManager.persist() —
+    // avoiding the merge()-triggered SELECT-then-INSERT "merge tax" on every
+    // create. @PostLoad/@PostPersist flip it false once Hibernate has seen the
+    // row, so update paths (which always load the managed entity first) keep
+    // going through merge()/dirty-checking. Excluded from Lombok's class-level
+    // @Getter/@Setter so the explicit isNew() override below doesn't collide.
+    @Transient
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private boolean isNew = true;
 
     String name;
 
@@ -93,6 +110,17 @@ public class Task {
     @PreUpdate
     public void preUpdate(){
         setUpdatedAt(Date.valueOf(LocalDate.now()));
+    }
+
+    @PostLoad
+    @PostPersist
+    void markNotNew(){
+        this.isNew = false;
+    }
+
+    @Override
+    public boolean isNew(){
+        return this.isNew;
     }
 
     public Task(CreateTaskRequestDTO createTaskDTO, Optional<List<Category>> categories, User user){

--- a/src/main/java/beyou/beyouapp/backend/domain/task/Task.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/task/Task.java
@@ -13,8 +13,6 @@ import beyou.beyouapp.backend.domain.task.dto.CreateTaskRequestDTO;
 import beyou.beyouapp.backend.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
@@ -35,10 +33,17 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 public class Task {
+    // No @GeneratedValue: Hibernate 7.4's merge() throws StaleObjectStateException
+    // when a manually-assigned id coexists with a generator annotation on an
+    // entity that has never been persisted (the offline-sync replay path).
+    // Field-initializing the id keeps every other construction path working
+    // (AI materialize flow, seeds, tests) since the initializer runs on `new`,
+    // while letting the mapper overwrite it with a client-supplied UUID when
+    // present. save() on a pre-set id goes through merge() (select-then-insert),
+    // and that select is the idempotency check.
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(updatable = false, nullable = false)
-    UUID id;
+    UUID id = UUID.randomUUID();
 
     String name;
 
@@ -61,11 +66,16 @@ public class Task {
     inverseJoinColumns = @JoinColumn(name = "category_id"))
     List<Category> categories;
 
+    // Field-initialized (not just @PrePersist) for the same reason as `id` above:
+    // an offline-sync replay merges a freshly-built transient graph onto the
+    // already-persisted row, and @PrePersist never fires on that UPDATE path —
+    // a null default here would null out the NOT NULL created_at/updated_at
+    // columns during merge.
     @Column(nullable = false)
-    private Date createdAt;
+    private Date createdAt = Date.valueOf(LocalDate.now());
 
     @Column(nullable = false)
-    private Date updatedAt;
+    private Date updatedAt = Date.valueOf(LocalDate.now());
 
     @ManyToOne
     @JsonIgnore

--- a/src/main/java/beyou/beyouapp/backend/domain/task/TaskMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/task/TaskMapper.java
@@ -22,7 +22,11 @@ public class TaskMapper {
 
     public Task toEntity(CreateTaskRequestDTO dto, List<Category> categories, User user) {
         List<Category> safeCategories = categories != null ? categories : Collections.emptyList();
-        return new Task(dto, Optional.of(safeCategories), user);
+        Task task = new Task(dto, Optional.of(safeCategories), user);
+        if (dto.id() != null) {
+            task.setId(dto.id());
+        }
+        return task;
     }
 
     public void updateEntity(Task task, EditTaskRequestDTO dto, List<Category> categories) {

--- a/src/main/java/beyou/beyouapp/backend/domain/task/TaskService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/task/TaskService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -99,6 +100,18 @@ public class TaskService {
 
     /** Core create: saves and returns the entity. Does NOT evict caches — callers decide. */
     public Task createTaskEntity(CreateTaskRequestDTO createTaskDTO, UUID userId){
+        if (createTaskDTO.id() != null) {
+            Optional<Task> existing = taskRepository.findById(createTaskDTO.id());
+            if (existing.isPresent()) {
+                if (!existing.get().getUser().getId().equals(userId)) {
+                    throw new BusinessException(ErrorKey.TASK_NOT_OWNED, "The task isn't of the user on context");
+                }
+                // Same user replaying a create (lost-response retry): true no-op —
+                // return the existing row untouched. This also keeps createdAt intact.
+                return existing.get();
+            }
+        }
+
         User user = userRepository.findById(userId).orElseThrow(() ->
         new UserNotFound("User not found when tried to create a task"));
 

--- a/src/main/java/beyou/beyouapp/backend/domain/task/dto/CreateTaskRequestDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/task/dto/CreateTaskRequestDTO.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CreateTaskRequestDTO(
+    UUID id,
     @NotEmpty @Size(min = 2, max = 256, message = "Task needs a minimum of 2 characters")
     String name,
     @Size(max = 1000, message = "Description is too long")

--- a/src/test/java/beyou/beyouapp/backend/controller/CategoryControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/CategoryControllerTest.java
@@ -58,7 +58,7 @@ public class CategoryControllerTest extends AbstractIntegrationTest {
         user.setId(userID);
 
         CategoryRequestDTO categoryRequestDTO = new CategoryRequestDTO(
-                "name", "icon", "desc",
+                null, "name", "icon", "desc",
                 ExperienceLevel.BEGINNER);
         category = new Category(categoryRequestDTO, user);
         categoryService.createCategory(categoryRequestDTO, userID);
@@ -78,7 +78,7 @@ public class CategoryControllerTest extends AbstractIntegrationTest {
     @Test
     void shouldCreateCategorySuccessfully() throws Exception {
         CategoryRequestDTO categoryRequestDTO = new CategoryRequestDTO(
-                "name", "icon", "desc",
+                null, "name", "icon", "desc",
                 ExperienceLevel.BEGINNER);
         Category category = new Category(categoryRequestDTO, user);
 

--- a/src/test/java/beyou/beyouapp/backend/controller/GoalControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/GoalControllerTest.java
@@ -95,7 +95,7 @@ private final ObjectMapper objectMapper = new ObjectMapper()
     @Test
     void shouldCreateGoalSuccessfully() throws Exception {
         CreateGoalRequestDTO dto = new CreateGoalRequestDTO(
-                "Name", "icon", "desc", 100.0, "unit", 0.0,
+                null, "Name", "icon", "desc", 100.0, "unit", 0.0,
                 List.of(UUID.randomUUID()), "motivation",
                 LocalDate.now(), LocalDate.now().plusDays(1),
                 GoalStatus.NOT_STARTED, GoalTerm.SHORT_TERM);

--- a/src/test/java/beyou/beyouapp/backend/controller/HabitControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/HabitControllerTest.java
@@ -80,7 +80,7 @@ public class HabitControllerTest extends AbstractIntegrationTest {
         List<UUID> categories = new ArrayList<>(List.of(UUID.randomUUID()));
 
         CreateHabitDTO createHabitDTO = new CreateHabitDTO(
-        "name", "", "", "icon1", 2, 2, categories, ExperienceLevel.BEGINNER);
+        null, "name", "", "", "icon1", 2, 2, categories, ExperienceLevel.BEGINNER);
 
         ResponseEntity<Map<String, String>> successResponse = ResponseEntity.ok().body(Map.of("success", "Habit saved successfully"));
 

--- a/src/test/java/beyou/beyouapp/backend/controller/RoutineControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/RoutineControllerTest.java
@@ -115,6 +115,7 @@ class RoutineControllerTest extends AbstractIntegrationTest {
     @Test
     void shouldCreateDiaryRoutine() throws Exception {
         DiaryRoutineRequestDTO requestDTO = new DiaryRoutineRequestDTO(
+                null,
                 "My routine",
                 "icon",
                 List.of(new RoutineSectionRequestDTO(null, "Morning", "sun", null, null, List.of(), List.of(), false)));
@@ -160,6 +161,7 @@ class RoutineControllerTest extends AbstractIntegrationTest {
     @Test
     void shouldUpdateDiaryRoutine() throws Exception {
         DiaryRoutineRequestDTO requestDTO = new DiaryRoutineRequestDTO(
+                null,
                 "Updated routine",
                 "icon-2",
                 List.of(new RoutineSectionRequestDTO(null, "Evening", "moon", null, null, List.of(), List.of(), true)));

--- a/src/test/java/beyou/beyouapp/backend/controller/TaskControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/TaskControllerTest.java
@@ -96,6 +96,7 @@ public class TaskControllerTest extends AbstractIntegrationTest {
     @Test
     void shouldCreateTaskSuccessfully() throws Exception {
         CreateTaskRequestDTO dto = new CreateTaskRequestDTO(
+            null,
             "Test Task",
             "Description",
             "icon1",

--- a/src/test/java/beyou/beyouapp/backend/integration/offline/ClientSuppliedIdIT.java
+++ b/src/test/java/beyou/beyouapp/backend/integration/offline/ClientSuppliedIdIT.java
@@ -1,6 +1,7 @@
 package beyou.beyouapp.backend.integration.offline;
 
 import beyou.beyouapp.backend.AbstractIntegrationTest;
+import beyou.beyouapp.backend.domain.category.Category;
 import beyou.beyouapp.backend.domain.category.CategoryRepository;
 import beyou.beyouapp.backend.domain.category.CategoryService;
 import beyou.beyouapp.backend.domain.category.dto.CategoryRequestDTO;
@@ -10,16 +11,21 @@ import beyou.beyouapp.backend.domain.goal.GoalService;
 import beyou.beyouapp.backend.domain.goal.GoalStatus;
 import beyou.beyouapp.backend.domain.goal.GoalTerm;
 import beyou.beyouapp.backend.domain.goal.dto.CreateGoalRequestDTO;
+import beyou.beyouapp.backend.domain.habit.Habit;
 import beyou.beyouapp.backend.domain.habit.HabitRepository;
 import beyou.beyouapp.backend.domain.habit.HabitService;
 import beyou.beyouapp.backend.domain.habit.dto.CreateHabitDTO;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutine;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutineRepository;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutineService;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.DiaryRoutineRequestDTO;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.RoutineSectionRequestDTO;
+import beyou.beyouapp.backend.domain.task.Task;
 import beyou.beyouapp.backend.domain.task.TaskRepository;
 import beyou.beyouapp.backend.domain.task.TaskService;
 import beyou.beyouapp.backend.domain.task.dto.CreateTaskRequestDTO;
+import beyou.beyouapp.backend.exceptions.BusinessException;
+import beyou.beyouapp.backend.exceptions.ErrorKey;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,12 +34,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -41,6 +49,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * optional client-supplied UUID. When present, the persisted entity keeps
  * that id, and replaying the same create (lost-response retry from an
  * offline mobile client) must not duplicate the row.
+ *
+ * Also locks in the cross-user ownership guard: a client-supplied id that
+ * already belongs to another user's row must never be hijacked/overwritten
+ * by a create call from a different user — the merge() behind a
+ * client-supplied id does a GLOBAL select, so this check is the only thing
+ * standing between "offline replay" and an IDOR.
+ *
+ * All five entities go through the PUBLIC service create methods here (not
+ * the internal *Entity helpers) so the tests exercise the same path the
+ * controllers use.
  */
 class ClientSuppliedIdIT extends AbstractIntegrationTest {
 
@@ -65,13 +83,21 @@ class ClientSuppliedIdIT extends AbstractIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        user = new User();
-        user.setName("Offline Sync IT User");
-        user.setEmail("offline-sync-" + UUID.randomUUID() + "@test.com");
-        user.setPassword("password123");
-        user = userRepository.saveAndFlush(user);
+        user = createUser();
         // XpByLevel rows are seeded by Flyway's R__seed_xp_by_level.sql (all levels).
     }
+
+    private User createUser() {
+        User newUser = new User();
+        newUser.setName("Offline Sync IT User");
+        newUser.setEmail("offline-sync-" + UUID.randomUUID() + "@test.com");
+        newUser.setPassword("password123");
+        return userRepository.saveAndFlush(newUser);
+    }
+
+    // ---------------------------------------------------------------------
+    // Idempotent replay (same user) — all five, through the public methods
+    // ---------------------------------------------------------------------
 
     @Test
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -79,10 +105,10 @@ class ClientSuppliedIdIT extends AbstractIntegrationTest {
         UUID clientId = UUID.randomUUID();
         CategoryRequestDTO dto = new CategoryRequestDTO(clientId, "Offline Cat", "icon-1", "desc", ExperienceLevel.BEGINNER);
 
-        categoryService.createCategoryEntity(dto, user);
+        categoryService.createCategory(dto, user.getId());
         assertTrue(categoryRepository.findById(clientId).isPresent());
 
-        categoryService.createCategoryEntity(dto, user); // replay — lost-response retry
+        categoryService.createCategory(dto, user.getId()); // replay — lost-response retry
         assertEquals(1, categoryRepository.findAllByUserId(user.getId()).orElseThrow().stream()
                 .filter(c -> c.getId().equals(clientId)).count());
     }
@@ -94,10 +120,10 @@ class ClientSuppliedIdIT extends AbstractIntegrationTest {
         CreateHabitDTO dto = new CreateHabitDTO(clientId, "Offline Habit", null, null, "icon-2", 3, 3,
                 List.of(), ExperienceLevel.BEGINNER);
 
-        habitService.createHabitEntity(dto, user.getId());
+        habitService.createHabit(dto, user.getId());
         assertTrue(habitRepository.findById(clientId).isPresent());
 
-        habitService.createHabitEntity(dto, user.getId()); // replay — lost-response retry
+        habitService.createHabit(dto, user.getId()); // replay — lost-response retry
         assertEquals(1, habitRepository.findAllByUserId(user.getId()).stream()
                 .filter(h -> h.getId().equals(clientId)).count());
     }
@@ -109,10 +135,10 @@ class ClientSuppliedIdIT extends AbstractIntegrationTest {
         CreateTaskRequestDTO dto = new CreateTaskRequestDTO(clientId, "Offline Task", null, "icon-3", 2, 2,
                 List.of(), false);
 
-        taskService.createTaskEntity(dto, user.getId());
+        taskService.createTask(dto, user.getId());
         assertTrue(taskRepository.findById(clientId).isPresent());
 
-        taskService.createTaskEntity(dto, user.getId()); // replay — lost-response retry
+        taskService.createTask(dto, user.getId()); // replay — lost-response retry
         assertEquals(1, taskRepository.findAllByUserId(user.getId()).orElseThrow().stream()
                 .filter(t -> t.getId().equals(clientId)).count());
     }
@@ -147,5 +173,178 @@ class ClientSuppliedIdIT extends AbstractIntegrationTest {
         diaryRoutineService.createDiaryRoutine(dto, user); // replay — lost-response retry
         assertEquals(1, diaryRoutineRepository.findAllByUserId(user.getId()).stream()
                 .filter(r -> r.getId().equals(clientId)).count());
+    }
+
+    // ---------------------------------------------------------------------
+    // Cross-user IDOR guard: user B create-replaying user A's id must be
+    // rejected with *_NOT_OWNED, and A's row must be left untouched.
+    // ---------------------------------------------------------------------
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void secondUserCannotHijackAnotherUsersCategoryViaClientSuppliedId() {
+        UUID clientId = UUID.randomUUID();
+        CategoryRequestDTO originalDto = new CategoryRequestDTO(clientId, "Owner Cat", "icon-1", "desc", ExperienceLevel.BEGINNER);
+        categoryService.createCategory(originalDto, user.getId());
+
+        User attacker = createUser();
+        CategoryRequestDTO hijackDto = new CategoryRequestDTO(clientId, "Hijacked Cat", "icon-evil", "evil", ExperienceLevel.BEGINNER);
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> categoryService.createCategory(hijackDto, attacker.getId()));
+        assertEquals(ErrorKey.CATEGORY_NOT_OWNED, exception.getErrorKey());
+
+        Category unchanged = categoryRepository.findById(clientId).orElseThrow();
+        assertEquals("Owner Cat", unchanged.getName());
+        assertEquals(user.getId(), unchanged.getUser().getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void secondUserCannotHijackAnotherUsersHabitViaClientSuppliedId() {
+        UUID clientId = UUID.randomUUID();
+        CreateHabitDTO originalDto = new CreateHabitDTO(clientId, "Owner Habit", null, null, "icon-2", 3, 3,
+                List.of(), ExperienceLevel.BEGINNER);
+        habitService.createHabit(originalDto, user.getId());
+
+        User attacker = createUser();
+        CreateHabitDTO hijackDto = new CreateHabitDTO(clientId, "Hijacked Habit", null, null, "icon-evil", 1, 1,
+                List.of(), ExperienceLevel.BEGINNER);
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> habitService.createHabit(hijackDto, attacker.getId()));
+        assertEquals(ErrorKey.HABIT_NOT_OWNED, exception.getErrorKey());
+
+        Habit unchanged = habitRepository.findById(clientId).orElseThrow();
+        assertEquals("Owner Habit", unchanged.getName());
+        assertEquals(user.getId(), unchanged.getUser().getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void secondUserCannotHijackAnotherUsersTaskViaClientSuppliedId() {
+        UUID clientId = UUID.randomUUID();
+        CreateTaskRequestDTO originalDto = new CreateTaskRequestDTO(clientId, "Owner Task", null, "icon-3", 2, 2,
+                List.of(), false);
+        taskService.createTask(originalDto, user.getId());
+
+        User attacker = createUser();
+        CreateTaskRequestDTO hijackDto = new CreateTaskRequestDTO(clientId, "Hijacked Task", null, "icon-evil", 1, 1,
+                List.of(), false);
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> taskService.createTask(hijackDto, attacker.getId()));
+        assertEquals(ErrorKey.TASK_NOT_OWNED, exception.getErrorKey());
+
+        Task unchanged = taskRepository.findById(clientId).orElseThrow();
+        assertEquals("Owner Task", unchanged.getName());
+        assertEquals(user.getId(), unchanged.getUser().getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void secondUserCannotHijackAnotherUsersGoalViaClientSuppliedId() {
+        UUID clientId = UUID.randomUUID();
+        CreateGoalRequestDTO originalDto = new CreateGoalRequestDTO(clientId, "Owner Goal", null, "icon-4", 10.0, "reps",
+                0.0, List.of(), null, LocalDate.now(), LocalDate.now().plusDays(30),
+                GoalStatus.NOT_STARTED, GoalTerm.SHORT_TERM);
+        goalService.createGoal(originalDto, user);
+
+        User attacker = createUser();
+        CreateGoalRequestDTO hijackDto = new CreateGoalRequestDTO(clientId, "Hijacked Goal", null, "icon-evil", 1.0, "reps",
+                0.0, List.of(), null, LocalDate.now(), LocalDate.now().plusDays(30),
+                GoalStatus.NOT_STARTED, GoalTerm.SHORT_TERM);
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> goalService.createGoal(hijackDto, attacker));
+        assertEquals(ErrorKey.GOAL_NOT_OWNED, exception.getErrorKey());
+
+        var unchanged = goalRepository.findById(clientId).orElseThrow();
+        assertEquals("Owner Goal", unchanged.getName());
+        assertEquals(user.getId(), unchanged.getUser().getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void secondUserCannotHijackAnotherUsersRoutineViaClientSuppliedId() {
+        UUID clientId = UUID.randomUUID();
+        RoutineSectionRequestDTO section = new RoutineSectionRequestDTO(null, "Morning", "icon", LocalTime.of(6, 0),
+                null, null, null, null);
+        DiaryRoutineRequestDTO originalDto = new DiaryRoutineRequestDTO(clientId, "Owner Routine", "icon-5", List.of(section));
+        diaryRoutineService.createDiaryRoutine(originalDto, user);
+
+        User attacker = createUser();
+        RoutineSectionRequestDTO hijackSection = new RoutineSectionRequestDTO(null, "Evil", "icon-evil", LocalTime.of(7, 0),
+                null, null, null, null);
+        DiaryRoutineRequestDTO hijackDto = new DiaryRoutineRequestDTO(clientId, "Hijacked Routine", "icon-evil", List.of(hijackSection));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> diaryRoutineService.createDiaryRoutine(hijackDto, attacker));
+        assertEquals(ErrorKey.ROUTINE_NOT_OWNED, exception.getErrorKey());
+
+        DiaryRoutine unchanged = diaryRoutineRepository.findById(clientId).orElseThrow();
+        assertEquals("Owner Routine", unchanged.getName());
+        assertEquals(user.getId(), unchanged.getUser().getId());
+    }
+
+    // ---------------------------------------------------------------------
+    // Replay preserves createdAt (Finding 2 — solved by Finding 1's design:
+    // returning the existing row untouched means no save() call at all).
+    // ---------------------------------------------------------------------
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void replayingCategoryCreatePreservesCreatedAt() {
+        UUID clientId = UUID.randomUUID();
+        CategoryRequestDTO dto = new CategoryRequestDTO(clientId, "Offline Cat", "icon-1", "desc", ExperienceLevel.BEGINNER);
+
+        categoryService.createCategory(dto, user.getId());
+        Date createdAt = categoryRepository.findById(clientId).orElseThrow().getCreatedAt();
+
+        categoryService.createCategory(dto, user.getId()); // replay — lost-response retry
+
+        Category afterReplay = categoryRepository.findById(clientId).orElseThrow();
+        assertEquals(createdAt, afterReplay.getCreatedAt());
+        assertEquals("Offline Cat", afterReplay.getName());
+        assertEquals(1, categoryRepository.findAllByUserId(user.getId()).orElseThrow().stream()
+                .filter(c -> c.getId().equals(clientId)).count());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void replayingHabitCreatePreservesCreatedAt() {
+        UUID clientId = UUID.randomUUID();
+        CreateHabitDTO dto = new CreateHabitDTO(clientId, "Offline Habit", null, null, "icon-2", 3, 3,
+                List.of(), ExperienceLevel.BEGINNER);
+
+        habitService.createHabit(dto, user.getId());
+        Date createdAt = habitRepository.findById(clientId).orElseThrow().getCreatedAt();
+
+        habitService.createHabit(dto, user.getId()); // replay — lost-response retry
+
+        Habit afterReplay = habitRepository.findById(clientId).orElseThrow();
+        assertEquals(createdAt, afterReplay.getCreatedAt());
+        assertEquals("Offline Habit", afterReplay.getName());
+        assertEquals(1, habitRepository.findAllByUserId(user.getId()).stream()
+                .filter(h -> h.getId().equals(clientId)).count());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void replayingTaskCreatePreservesCreatedAt() {
+        UUID clientId = UUID.randomUUID();
+        CreateTaskRequestDTO dto = new CreateTaskRequestDTO(clientId, "Offline Task", null, "icon-3", 2, 2,
+                List.of(), false);
+
+        taskService.createTask(dto, user.getId());
+        Date createdAt = taskRepository.findById(clientId).orElseThrow().getCreatedAt();
+
+        taskService.createTask(dto, user.getId()); // replay — lost-response retry
+
+        Task afterReplay = taskRepository.findById(clientId).orElseThrow();
+        assertEquals(createdAt, afterReplay.getCreatedAt());
+        assertEquals("Offline Task", afterReplay.getName());
+        assertEquals(1, taskRepository.findAllByUserId(user.getId()).orElseThrow().stream()
+                .filter(t -> t.getId().equals(clientId)).count());
     }
 }

--- a/src/test/java/beyou/beyouapp/backend/integration/offline/ClientSuppliedIdIT.java
+++ b/src/test/java/beyou/beyouapp/backend/integration/offline/ClientSuppliedIdIT.java
@@ -1,0 +1,151 @@
+package beyou.beyouapp.backend.integration.offline;
+
+import beyou.beyouapp.backend.AbstractIntegrationTest;
+import beyou.beyouapp.backend.domain.category.CategoryRepository;
+import beyou.beyouapp.backend.domain.category.CategoryService;
+import beyou.beyouapp.backend.domain.category.dto.CategoryRequestDTO;
+import beyou.beyouapp.backend.domain.common.ExperienceLevel;
+import beyou.beyouapp.backend.domain.goal.GoalRepository;
+import beyou.beyouapp.backend.domain.goal.GoalService;
+import beyou.beyouapp.backend.domain.goal.GoalStatus;
+import beyou.beyouapp.backend.domain.goal.GoalTerm;
+import beyou.beyouapp.backend.domain.goal.dto.CreateGoalRequestDTO;
+import beyou.beyouapp.backend.domain.habit.HabitRepository;
+import beyou.beyouapp.backend.domain.habit.HabitService;
+import beyou.beyouapp.backend.domain.habit.dto.CreateHabitDTO;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutineRepository;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutineService;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.DiaryRoutineRequestDTO;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.RoutineSectionRequestDTO;
+import beyou.beyouapp.backend.domain.task.TaskRepository;
+import beyou.beyouapp.backend.domain.task.TaskService;
+import beyou.beyouapp.backend.domain.task.dto.CreateTaskRequestDTO;
+import beyou.beyouapp.backend.user.User;
+import beyou.beyouapp.backend.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Locks in the offline-sync wire contract: every create endpoint accepts an
+ * optional client-supplied UUID. When present, the persisted entity keeps
+ * that id, and replaying the same create (lost-response retry from an
+ * offline mobile client) must not duplicate the row.
+ */
+class ClientSuppliedIdIT extends AbstractIntegrationTest {
+
+    @Autowired private CategoryService categoryService;
+    @Autowired private CategoryRepository categoryRepository;
+
+    @Autowired private HabitService habitService;
+    @Autowired private HabitRepository habitRepository;
+
+    @Autowired private TaskService taskService;
+    @Autowired private TaskRepository taskRepository;
+
+    @Autowired private GoalService goalService;
+    @Autowired private GoalRepository goalRepository;
+
+    @Autowired private DiaryRoutineService diaryRoutineService;
+    @Autowired private DiaryRoutineRepository diaryRoutineRepository;
+
+    @Autowired private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setName("Offline Sync IT User");
+        user.setEmail("offline-sync-" + UUID.randomUUID() + "@test.com");
+        user.setPassword("password123");
+        user = userRepository.saveAndFlush(user);
+        // XpByLevel rows are seeded by Flyway's R__seed_xp_by_level.sql (all levels).
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void createCategoryKeepsClientSuppliedIdAndReplayIsIdempotent() {
+        UUID clientId = UUID.randomUUID();
+        CategoryRequestDTO dto = new CategoryRequestDTO(clientId, "Offline Cat", "icon-1", "desc", ExperienceLevel.BEGINNER);
+
+        categoryService.createCategoryEntity(dto, user);
+        assertTrue(categoryRepository.findById(clientId).isPresent());
+
+        categoryService.createCategoryEntity(dto, user); // replay — lost-response retry
+        assertEquals(1, categoryRepository.findAllByUserId(user.getId()).orElseThrow().stream()
+                .filter(c -> c.getId().equals(clientId)).count());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void createHabitKeepsClientSuppliedIdAndReplayIsIdempotent() {
+        UUID clientId = UUID.randomUUID();
+        CreateHabitDTO dto = new CreateHabitDTO(clientId, "Offline Habit", null, null, "icon-2", 3, 3,
+                List.of(), ExperienceLevel.BEGINNER);
+
+        habitService.createHabitEntity(dto, user.getId());
+        assertTrue(habitRepository.findById(clientId).isPresent());
+
+        habitService.createHabitEntity(dto, user.getId()); // replay — lost-response retry
+        assertEquals(1, habitRepository.findAllByUserId(user.getId()).stream()
+                .filter(h -> h.getId().equals(clientId)).count());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void createTaskKeepsClientSuppliedIdAndReplayIsIdempotent() {
+        UUID clientId = UUID.randomUUID();
+        CreateTaskRequestDTO dto = new CreateTaskRequestDTO(clientId, "Offline Task", null, "icon-3", 2, 2,
+                List.of(), false);
+
+        taskService.createTaskEntity(dto, user.getId());
+        assertTrue(taskRepository.findById(clientId).isPresent());
+
+        taskService.createTaskEntity(dto, user.getId()); // replay — lost-response retry
+        assertEquals(1, taskRepository.findAllByUserId(user.getId()).orElseThrow().stream()
+                .filter(t -> t.getId().equals(clientId)).count());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void createGoalKeepsClientSuppliedIdAndReplayIsIdempotent() {
+        UUID clientId = UUID.randomUUID();
+        CreateGoalRequestDTO dto = new CreateGoalRequestDTO(clientId, "Offline Goal", null, "icon-4", 10.0, "reps",
+                0.0, List.of(), null, LocalDate.now(), LocalDate.now().plusDays(30),
+                GoalStatus.NOT_STARTED, GoalTerm.SHORT_TERM);
+
+        goalService.createGoal(dto, user);
+        assertTrue(goalRepository.findById(clientId).isPresent());
+
+        goalService.createGoal(dto, user); // replay — lost-response retry
+        assertEquals(1, goalRepository.findAllByUserId(user.getId()).orElseThrow().stream()
+                .filter(g -> g.getId().equals(clientId)).count());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void createRoutineKeepsClientSuppliedIdAndReplayIsIdempotent() {
+        UUID clientId = UUID.randomUUID();
+        RoutineSectionRequestDTO section = new RoutineSectionRequestDTO(null, "Morning", "icon", LocalTime.of(6, 0),
+                null, null, null, null);
+        DiaryRoutineRequestDTO dto = new DiaryRoutineRequestDTO(clientId, "Offline Routine", "icon-5", List.of(section));
+
+        diaryRoutineService.createDiaryRoutine(dto, user);
+        assertTrue(diaryRoutineRepository.findById(clientId).isPresent());
+
+        diaryRoutineService.createDiaryRoutine(dto, user); // replay — lost-response retry
+        assertEquals(1, diaryRoutineRepository.findAllByUserId(user.getId()).stream()
+                .filter(r -> r.getId().equals(clientId)).count());
+    }
+}

--- a/src/test/java/beyou/beyouapp/backend/integration/routine/DiaryRoutineUpdateOrphanIT.java
+++ b/src/test/java/beyou/beyouapp/backend/integration/routine/DiaryRoutineUpdateOrphanIT.java
@@ -59,9 +59,9 @@ class DiaryRoutineUpdateOrphanIT extends AbstractIntegrationTest {
         if (xpByLevelRepository.findByLevel(1) == null) xpByLevelRepository.save(new XpByLevel(1, 100));
 
         Category category = categoryService.createCategoryEntity(
-                new CategoryRequestDTO("Health", "ic", null, ExperienceLevel.BEGINNER), user);
+                new CategoryRequestDTO(null, "Health", "ic", null, ExperienceLevel.BEGINNER), user);
         habitId = habitService.createHabitEntity(
-                new CreateHabitDTO("Read", null, null, "ic", 3, 3, List.of(category.getId()),
+                new CreateHabitDTO(null, "Read", null, null, "ic", 3, 3, List.of(category.getId()),
                         ExperienceLevel.BEGINNER),
                 user.getId()).getId();
     }
@@ -78,7 +78,7 @@ class DiaryRoutineUpdateOrphanIT extends AbstractIntegrationTest {
                 null, "B", "ic", LocalTime.of(8, 0), LocalTime.of(9, 0), List.of(), List.of(), false);
 
         DiaryRoutineResponseDTO created = diaryRoutineService.createDiaryRoutine(
-                new DiaryRoutineRequestDTO("R", "", List.of(sectionA, sectionB)), user);
+                new DiaryRoutineRequestDTO(null, "R", "", List.of(sectionA, sectionB)), user);
         assertEquals(2, created.routineSections().size());
         UUID routineId = created.id();
         UUID sectionBId = created.routineSections().stream()
@@ -87,7 +87,7 @@ class DiaryRoutineUpdateOrphanIT extends AbstractIntegrationTest {
         RoutineSectionRequestDTO keepB = new RoutineSectionRequestDTO(
                 sectionBId, "B", "ic", LocalTime.of(8, 0), LocalTime.of(9, 0), List.of(), List.of(), false);
         diaryRoutineService.updateDiaryRoutine(routineId,
-                new DiaryRoutineRequestDTO("R", "", List.of(keepB)), user.getId());
+                new DiaryRoutineRequestDTO(null, "R", "", List.of(keepB)), user.getId());
 
         transactionTemplate.executeWithoutResult(tx -> {
             DiaryRoutine routine = diaryRoutineRepository.findById(routineId).orElseThrow();

--- a/src/test/java/beyou/beyouapp/backend/unit/category/CategoryServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/category/CategoryServiceUnitTest.java
@@ -55,7 +55,7 @@ public class CategoryServiceUnitTest {
     UUID userId = UUID.randomUUID();
     Category category = new Category();
     UUID categoryId = UUID.randomUUID();
-    CategoryRequestDTO categoryRequestDTO = new CategoryRequestDTO("Life", "test", "My life in category", ExperienceLevel.BEGINNER);
+    CategoryRequestDTO categoryRequestDTO = new CategoryRequestDTO(null, "Life", "test", "My life in category", ExperienceLevel.BEGINNER);
     XpByLevel xpByLevel = new XpByLevel();
     XpByLevel xpByLevel2 = new XpByLevel();
     @BeforeEach
@@ -164,7 +164,7 @@ public class CategoryServiceUnitTest {
     @Test
     public void shouldThrowAExceptionOfUserNotFoundWhenTryingToCreateACategoryWithWrongUserId(){
         Exception exception = assertThrows(UserNotFound.class, () -> {
-            CategoryRequestDTO categoryRequestDTO = new CategoryRequestDTO("Life", "test",
+            CategoryRequestDTO categoryRequestDTO = new CategoryRequestDTO(null, "Life", "test",
                     "My life in category", ExperienceLevel.BEGINNER);
             categoryService.createCategory(categoryRequestDTO, UUID.randomUUID());
         });

--- a/src/test/java/beyou/beyouapp/backend/unit/goal/goalServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/goal/goalServiceUnitTest.java
@@ -133,7 +133,7 @@ public class goalServiceUnitTest {
     @Test
     void shouldCreateGoalSuccessfully() {
         CreateGoalRequestDTO dto = new CreateGoalRequestDTO(
-                "Name", "icon", "desc", 100.0, "unit", 0.0,
+                null, "Name", "icon", "desc", 100.0, "unit", 0.0,
                 List.of(UUID.randomUUID()), "motivation",
                 LocalDate.now(), LocalDate.now().plusDays(1),
                 GoalStatus.NOT_STARTED, GoalTerm.SHORT_TERM);
@@ -153,7 +153,7 @@ public class goalServiceUnitTest {
     @Test
     void shouldReturnBadRequest_whenCreateGoalSaveFails() {
         CreateGoalRequestDTO dto = new CreateGoalRequestDTO(
-                "Name", "icon", "desc", 100.0, "unit", 0.0,
+                null, "Name", "icon", "desc", 100.0, "unit", 0.0,
                 List.of(UUID.randomUUID()), "motivation",
                 LocalDate.now(), LocalDate.now().plusDays(1),
                 GoalStatus.NOT_STARTED, GoalTerm.SHORT_TERM);

--- a/src/test/java/beyou/beyouapp/backend/unit/habit/HabitServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/habit/HabitServiceUnitTest.java
@@ -102,7 +102,7 @@ public class HabitServiceUnitTest {
     @Test
     public void shouldCreateHabitSuccessfully(){
         CreateHabitDTO createHabitDTO = new CreateHabitDTO(
-        "name", "", "", "", 2, 2,
+        null, "name", "", "", "", 2, 2,
         categories, ExperienceLevel.BEGINNER);
 
         XpByLevel xpByLevel = new XpByLevel(0, 0);

--- a/src/test/java/beyou/beyouapp/backend/unit/routine/DiaryRoutineServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/routine/DiaryRoutineServiceUnitTest.java
@@ -88,7 +88,7 @@ class DiaryRoutineServiceUnitTest {
         User user = new User();
         user.setId(userId);
 
-        validRequestDTO = new DiaryRoutineRequestDTO(
+        validRequestDTO = new DiaryRoutineRequestDTO(null, 
                 "Rotina Diária",
                 "routine-icon-123",
                 new ArrayList<>(
@@ -181,7 +181,7 @@ class DiaryRoutineServiceUnitTest {
     @Test
     @DisplayName("Should throw IllegalArgumentException when creating with empty name")
     void shouldThrowExceptionWhenCreatingWithEmptyName() {
-        DiaryRoutineRequestDTO invalidDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO invalidDTO = new DiaryRoutineRequestDTO(null, 
                 "",
                 "routine-icon-123",
                 validRequestDTO.routineSections());
@@ -197,7 +197,7 @@ class DiaryRoutineServiceUnitTest {
     @Test
     @DisplayName("Should allow overnight routine section time range")
     void shouldAllowOvernightSectionTimeRange() {
-        DiaryRoutineRequestDTO overnightDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO overnightDTO = new DiaryRoutineRequestDTO(null, 
                 "Rotina Diária",
                 "routine-icon-123",
                 List.of(
@@ -221,7 +221,7 @@ class DiaryRoutineServiceUnitTest {
     @Test
     @DisplayName("Should throw IllegalArgumentException when item endTime is before item startTime")
     void shouldThrowExceptionWhenItemEndTimeBeforeStartTime() {
-        DiaryRoutineRequestDTO invalidDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO invalidDTO = new DiaryRoutineRequestDTO(null, 
                 "Rotina Diária",
                 "routine-icon-123",
                 List.of(
@@ -253,7 +253,7 @@ class DiaryRoutineServiceUnitTest {
     @Test
     @DisplayName("Should throw IllegalArgumentException when item endTime is outside section bounds")
     void shouldThrowExceptionWhenItemEndTimeOutsideSectionBounds() {
-        DiaryRoutineRequestDTO invalidDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO invalidDTO = new DiaryRoutineRequestDTO(null, 
                 "Rotina Diária",
                 "routine-icon-123",
                 List.of(
@@ -323,7 +323,7 @@ class DiaryRoutineServiceUnitTest {
     @Test
     @DisplayName("Should update diary routine successfully")
     void shouldUpdateDiaryRoutineSuccessfully() {
-        DiaryRoutineRequestDTO updatedDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO updatedDTO = new DiaryRoutineRequestDTO(null, 
                 "New routine updated",
                 "routine-icon-updated",
                 new ArrayList<>(
@@ -517,7 +517,7 @@ class DiaryRoutineServiceUnitTest {
         assertEquals(1, existingSection.getHabitGroups().size(), "Precondition: should start with 1 habit group");
 
         // Send update with existing section ID but empty habitGroup list (keep taskGroup)
-        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(null, 
                 "Updated",
                 "icon",
                 List.of(new RoutineSectionRequestDTO(
@@ -550,7 +550,7 @@ class DiaryRoutineServiceUnitTest {
 
         assertEquals(1, existingSection.getTaskGroups().size(), "Precondition: should start with 1 task group");
 
-        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(null, 
                 "Updated",
                 "icon",
                 List.of(new RoutineSectionRequestDTO(
@@ -592,7 +592,7 @@ class DiaryRoutineServiceUnitTest {
         when(diaryRoutineRepository.findById(routineId)).thenReturn(Optional.of(diaryRoutine));
         when(habitService.getHabit(newHabitId)).thenReturn(newHabit);
 
-        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(null, 
                 "Updated",
                 "icon",
                 List.of(new RoutineSectionRequestDTO(
@@ -633,7 +633,7 @@ class DiaryRoutineServiceUnitTest {
 
         when(diaryRoutineRepository.findById(routineId)).thenReturn(Optional.of(diaryRoutine));
 
-        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(null, 
                 "Updated",
                 "icon",
                 List.of(new RoutineSectionRequestDTO(
@@ -669,7 +669,7 @@ class DiaryRoutineServiceUnitTest {
 
         when(diaryRoutineRepository.findById(routineId)).thenReturn(Optional.of(diaryRoutine));
 
-        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(null, 
                 "Updated",
                 "icon",
                 List.of(new RoutineSectionRequestDTO(
@@ -705,7 +705,7 @@ class DiaryRoutineServiceUnitTest {
         when(diaryRoutineRepository.findById(routineId)).thenReturn(Optional.of(diaryRoutine));
         when(habitService.getHabit(foreignHabitId)).thenReturn(foreignHabit);
 
-        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(null, 
                 "Updated",
                 "icon",
                 List.of(new RoutineSectionRequestDTO(
@@ -745,7 +745,7 @@ class DiaryRoutineServiceUnitTest {
         when(diaryRoutineRepository.findById(routineId)).thenReturn(Optional.of(diaryRoutine));
         when(taskService.getTask(foreignTaskId)).thenReturn(foreignTask);
 
-        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(
+        DiaryRoutineRequestDTO updateDTO = new DiaryRoutineRequestDTO(null, 
                 "Updated",
                 "icon",
                 List.of(new RoutineSectionRequestDTO(

--- a/src/test/java/beyou/beyouapp/backend/unit/routine/checks/CheckItemServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/routine/checks/CheckItemServiceUnitTest.java
@@ -120,6 +120,29 @@ class CheckItemServiceUnitTest {
         }
 
         @Test
+        void checkHonorsExplicitDateFromDto() {
+            LocalDate yesterday = LocalDate.now().minusDays(1);
+            Category category = createCategory(0);
+            Habit habit = createHabit(2, 3, 0, 0, List.of(category));
+            HabitGroup habitGroup = createHabitGroup(habit);
+
+            DiaryRoutine routine = (DiaryRoutine) habitGroup.getRoutineSection().getRoutine();
+            UUID routineId = routine.getId();
+            when(itemGroupService.findHabitGroupByDTO(routineId, habitGroup.getId())).thenReturn(habitGroup);
+
+            checkItemService.checkOrUncheckItemGroup(
+                    new CheckGroupRequestDTO(
+                            routineId,
+                            null,
+                            new HabitGroupRequestDTO(habitGroup.getId(), habitGroup.getStartTime()),
+                            yesterday));
+
+            assertEquals(1, habitGroup.getHabitGroupChecks().size());
+            HabitGroupCheck check = habitGroup.getHabitGroupChecks().get(0);
+            assertEquals(yesterday, check.getCheckDate());
+        }
+
+        @Test
         void shouldUncheckHabitGroupAndRollbackXp() {
             LocalDate date = LocalDate.now();
             Category category = createCategory(40);

--- a/src/test/java/beyou/beyouapp/backend/unit/task/TaskServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/task/TaskServiceUnitTest.java
@@ -95,10 +95,11 @@ public class TaskServiceUnitTest {
         category.setId(categoriesId.get(0));
 
         CreateTaskRequestDTO createTaskDTO = new CreateTaskRequestDTO(
+        null,
         "taskName",
-        "Task description", 
+        "Task description",
         "IconId",
-        2, 
+        2,
         2,
         categoriesId,
         false);
@@ -116,8 +117,9 @@ public class TaskServiceUnitTest {
     @Test
     public void shouldCreateACategoryWithoutTheOptionalAttributes(){
         CreateTaskRequestDTO createTaskDTO = new CreateTaskRequestDTO(
+        null,
         "taskName",
-        "Task description", 
+        "Task description",
         "IconId",
         null,
         null,
@@ -183,7 +185,7 @@ public class TaskServiceUnitTest {
     @Test
     public void shouldThrowExceptionWhenUserNotFoundCreatingTask() {
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
-        CreateTaskRequestDTO createTaskDTO = new CreateTaskRequestDTO("task", "desc", "icon", 1, 1, null, false);
+        CreateTaskRequestDTO createTaskDTO = new CreateTaskRequestDTO(null, "task", "desc", "icon", 1, 1, null, false);
         assertThrows(UserNotFound.class, () -> taskService.createTask(createTaskDTO, userId));
     }
 


### PR DESCRIPTION
## Summary

Two small backend changes to support the offline-writes mobile client (Beyou-Frontend Phase 2):

1. **Optional client-supplied `id` on all 5 Create DTOs** — `CategoryRequestDTO`, `CreateHabitDTO`, `CreateTaskRequestDTO`, `CreateGoalRequestDTO`, `DiaryRoutineRequestDTO`. When present, the persisted entity keeps that id (the mobile client pre-assigns UUIDs to entities created offline). Replaying the same create twice is idempotent — the second call is a no-op, not a duplicate. Cross-user id injection is rejected (`*_NOT_OWNED` BusinessException).

2. **`POST /routine/check` now honors `CheckGroupRequestDTO.date`** — was hardcoded `LocalDate.now()` while the skip path already honored it. An offline check made at 23:50 and replayed at 00:10 now credits XP/constance on the original day.

## Test plan
- [x] `ClientSuppliedIdIT` — 13/13 (client-id persistence + replay idempotency + cross-user rejection, per entity)
- [x] `CheckItemServiceUnitTest` — 8/8 (including `checkHonorsExplicitDateFromDto`)
- [x] Full suite `./mvnw test` — 425/425 green