### PR TITLE
fix(photo): don't fail app startup when upload dir isn't writable

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/user/PhotoStorageService.java
+++ b/src/main/java/beyou/beyouapp/backend/user/PhotoStorageService.java
@@ -48,7 +48,12 @@ public class PhotoStorageService {
         try {
             Files.createDirectories(this.uploadDir);
         } catch (IOException e) {
-            throw new RuntimeException("Could not create upload directory: " + this.uploadDir, e);
+            // Best-effort at startup. Photo upload is an optional feature — a
+            // non-writable dir must NOT take down the whole application context
+            // (auth, routines, etc.). store() recreates the directory on the write
+            // path and surfaces a proper PHOTO_UPLOAD error if it genuinely can't.
+            log.warn("Could not pre-create upload directory {} at startup; will retry on first upload",
+                this.uploadDir, e);
         }
     }
 


### PR DESCRIPTION
PhotoStorageService's constructor threw a RuntimeException when it couldn't create the upload directory, which failed the ENTIRE Spring context — taking down auth/routines/everything for an optional avatar feature. In the e2e container UPLOAD_DIR is unset (dev-env#9 not merged, and the e2e job pins Beyou-dev-env to main), so app.upload-dir defaulted to ./uploads = /app/uploads, unwritable by appuser → boot crash → every API-hitting e2e spec got ECONNREFUSED.

Log a warning and continue instead; store() already recreates the directory on the write path and surfaces a proper PHOTO_UPLOAD error if it truly can't.