### PR TITLE
fix(routine): adding a task on update NPE'd and rolled the edit back

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/domain/routine/itemGroup/TaskGroup.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/itemGroup/TaskGroup.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.annotations.BatchSize;
@@ -29,5 +30,5 @@ public class TaskGroup extends ItemGroup {
     
     @OneToMany(mappedBy = "taskGroup", cascade = CascadeType.ALL, orphanRemoval = false)
     @BatchSize(size = 50)
-    private List<TaskGroupCheck> taskGroupChecks;
+    private List<TaskGroupCheck> taskGroupChecks = new ArrayList<>();
 }

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutineMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutineMapper.java
@@ -184,7 +184,9 @@ public class DiaryRoutineMapper {
                         taskGroup.getTask().getId(),
                         formatTime(taskGroup.getStartTime()),
                         formatTime(taskGroup.getEndTime()),
-                        new ArrayList<>(taskGroup.getTaskGroupChecks())))
+                        taskGroup.getTaskGroupChecks() == null
+                                ? new ArrayList<>()
+                                : new ArrayList<>(taskGroup.getTaskGroupChecks())))
                 .collect(Collectors.toList());
 
         List<DiaryRoutineResponseDTO.RoutineSectionResponseDTO.HabitGroupResponseDTO> habitGroupDTOs = section
@@ -194,7 +196,9 @@ public class DiaryRoutineMapper {
                         habitGroup.getHabit().getId(),
                         formatTime(habitGroup.getStartTime()),
                         formatTime(habitGroup.getEndTime()),
-                        new ArrayList<>(habitGroup.getHabitGroupChecks())))
+                        habitGroup.getHabitGroupChecks() == null
+                                ? new ArrayList<>()
+                                : new ArrayList<>(habitGroup.getHabitGroupChecks())))
                 .collect(Collectors.toList());
 
         return new DiaryRoutineResponseDTO.RoutineSectionResponseDTO(

--- a/src/test/java/beyou/beyouapp/backend/integration/routine/DiaryRoutineUpdateOrphanIT.java
+++ b/src/test/java/beyou/beyouapp/backend/integration/routine/DiaryRoutineUpdateOrphanIT.java
@@ -17,6 +17,9 @@ import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.DiaryRoutin
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.DiaryRoutineResponseDTO;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.HabitGroupDTO;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.RoutineSectionRequestDTO;
+import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.TaskGroupDTO;
+import beyou.beyouapp.backend.domain.task.TaskService;
+import beyou.beyouapp.backend.domain.task.dto.CreateTaskRequestDTO;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +44,7 @@ class DiaryRoutineUpdateOrphanIT extends AbstractIntegrationTest {
     @Autowired private HabitRepository habitRepository;
     @Autowired private CategoryService categoryService;
     @Autowired private HabitService habitService;
+    @Autowired private TaskService taskService;
     @Autowired private UserRepository userRepository;
     @Autowired private XpByLevelRepository xpByLevelRepository;
     @Autowired private TransactionTemplate transactionTemplate;
@@ -98,5 +102,40 @@ class DiaryRoutineUpdateOrphanIT extends AbstractIntegrationTest {
 
         assertTrue(habitRepository.findById(habitId).isPresent(),
                 "habit survives — only its routine membership was deleted");
+    }
+
+    /**
+     * Regression: adding a NEW task group on update used to NPE in
+     * toResponse (TaskGroup.taskGroupChecks was left null by the
+     * mergeTaskGroups create path) — surfaced by the AI agent, but any
+     * PUT /routine adding a task hit it, rolling the whole edit back.
+     */
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void updateAddingNewTaskGroupSucceedsWithEmptyChecks() {
+        RoutineSectionRequestDTO section = new RoutineSectionRequestDTO(
+                null, "A", "ic", LocalTime.of(6, 0), LocalTime.of(7, 0), List.of(), List.of(), false);
+        DiaryRoutineResponseDTO created = diaryRoutineService.createDiaryRoutine(
+                new DiaryRoutineRequestDTO("R", "", List.of(section)), user);
+        UUID routineId = created.id();
+        UUID sectionId = created.routineSections().get(0).id();
+
+        UUID taskId = taskService.createTaskEntity(
+                new CreateTaskRequestDTO("Estudar", null, "ic", 3, 3, List.of(), false),
+                user.getId()).getId();
+
+        RoutineSectionRequestDTO withTask = new RoutineSectionRequestDTO(
+                sectionId, "A", "ic", LocalTime.of(6, 0), LocalTime.of(7, 0),
+                List.of(new TaskGroupDTO(null, taskId, LocalTime.of(6, 0), LocalTime.of(6, 30), null)),
+                List.of(), false);
+
+        DiaryRoutineResponseDTO updated = diaryRoutineService.updateDiaryRoutine(routineId,
+                new DiaryRoutineRequestDTO("R", "", List.of(withTask)), user.getId());
+
+        var taskGroups = updated.routineSections().get(0).taskGroup();
+        assertEquals(1, taskGroups.size());
+        assertEquals(taskId, taskGroups.get(0).taskId());
+        assertTrue(taskGroups.get(0).taskGroupChecks().isEmpty(),
+                "a freshly added group has an empty (never null) check list");
     }
 }


### PR DESCRIPTION
## What

`PUT /routine` adding a **new task group** always failed: `mergeTaskGroups`' create path leaves `TaskGroup.taskGroupChecks` null (`HabitGroup` has a field initializer, `TaskGroup` didn't), `toResponse` does `new ArrayList<>(null)` → NPE → `@Transactional` rolls the whole edit back.

Surfaced by the AI agent trying to add a task to a routine, but any client hits it.

- `TaskGroup.taskGroupChecks = new ArrayList<>()` (mirrors HabitGroup)
- Null-safe check-list mapping in `DiaryRoutineMapper.mapSectionToResponse` as belt-and-braces
- Regression IT: update adding a new task group succeeds with an empty check list

## Test plan
- [x] New regression IT (fails on main, passes here)
- [x] Full suite green from clean build (400 tests, 0 failures)