### PR TITLE
feat(agent): SSE streaming, tool events, persisted transcript (phase 4)

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/controllers/AiAgentController.java
+++ b/src/main/java/beyou/beyouapp/backend/controllers/AiAgentController.java
@@ -17,7 +17,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import beyou.beyouapp.backend.domain.aiAgent.AiAgentService;
 import beyou.beyouapp.backend.domain.aiAgent.chat.ChatService;
-import beyou.beyouapp.backend.domain.aiAgent.chat.dto.ChatMessageDTO;
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentMessageDTO;
 import beyou.beyouapp.backend.domain.aiAgent.chat.dto.ChatResponseDTO;
 import beyou.beyouapp.backend.domain.aiAgent.dto.CreateChatRequest;
 import beyou.beyouapp.backend.domain.aiAgent.dto.AiAgentRequest;
@@ -63,7 +63,7 @@ public class AiAgentController {
     }
 
     @GetMapping("/chats/{chatId}/messages")
-    public List<ChatMessageDTO> getMessages(@PathVariable UUID chatId) {
+    public List<AgentMessageDTO> getMessages(@PathVariable UUID chatId) {
         UUID userId = authenticatedUser.getAuthenticatedUser().getId();
         return agentService.getMessages(chatId, userId);
     }

--- a/src/main/java/beyou/beyouapp/backend/controllers/AiAgentController.java
+++ b/src/main/java/beyou/beyouapp/backend/controllers/AiAgentController.java
@@ -22,6 +22,7 @@ import beyou.beyouapp.backend.domain.aiAgent.chat.dto.ChatResponseDTO;
 import beyou.beyouapp.backend.domain.aiAgent.dto.CreateChatRequest;
 import beyou.beyouapp.backend.domain.aiAgent.dto.AiAgentRequest;
 import beyou.beyouapp.backend.security.AuthenticatedUser;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,9 +57,14 @@ public class AiAgentController {
     }
 
     @PostMapping(value = "/chats/{chatId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter streamMessage(@PathVariable UUID chatId, @RequestBody @Valid AiAgentRequest request) {
+    public SseEmitter streamMessage(@PathVariable UUID chatId, @RequestBody @Valid AiAgentRequest request,
+            HttpServletResponse response) {
         UUID userId = authenticatedUser.getAuthenticatedUser().getId();
         log.info("Receiving agent message on chat {} for user {}", chatId, userId);
+        // Tell nginx (and any proxy honoring it) not to buffer this response,
+        // so tokens flush to the client immediately instead of in one blob.
+        response.setHeader("X-Accel-Buffering", "no");
+        response.setHeader("Cache-Control", "no-cache");
         return agentService.streamMessage(chatId, request.userInput(), userId, request.currentPage());
     }
 

--- a/src/main/java/beyou/beyouapp/backend/controllers/AiAgentController.java
+++ b/src/main/java/beyou/beyouapp/backend/controllers/AiAgentController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import beyou.beyouapp.backend.domain.aiAgent.AiAgentService;
 import beyou.beyouapp.backend.domain.aiAgent.chat.ChatService;
@@ -51,6 +53,13 @@ public class AiAgentController {
         log.info("Receiving agent message on chat {} for user {}", chatId, userId);
         return Map.of("reply",
                 agentService.processMessage(chatId, request.userInput(), userId, request.currentPage()));
+    }
+
+    @PostMapping(value = "/chats/{chatId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamMessage(@PathVariable UUID chatId, @RequestBody @Valid AiAgentRequest request) {
+        UUID userId = authenticatedUser.getAuthenticatedUser().getId();
+        log.info("Receiving agent message on chat {} for user {}", chatId, userId);
+        return agentService.streamMessage(chatId, request.userInput(), userId, request.currentPage());
     }
 
     @GetMapping("/chats/{chatId}/messages")

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AgentToolDomains.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AgentToolDomains.java
@@ -1,0 +1,56 @@
+package beyou.beyouapp.backend.domain.aiAgent;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Which frontend domains a WRITE tool touches — travels inside the
+ * toolFinished event so the client refetches exactly what changed.
+ * Read tools (and context tools, whose data has no UI yet) return empty.
+ * Domain names match the frontend Redux slices.
+ */
+public final class AgentToolDomains {
+
+    private static final Map<String, List<String>> WRITE_TOOLS = Map.ofEntries(
+            // Habits
+            Map.entry("createUserHabit", List.of("habits")),
+            Map.entry("editUserHabit", List.of("habits")),
+            Map.entry("deleteUserHabit", List.of("habits")),
+            // Categories (habit cards embed category data, so refresh both)
+            Map.entry("createUserCategory", List.of("categories")),
+            Map.entry("editUserCategory", List.of("categories", "habits")),
+            Map.entry("deleteUserCategory", List.of("categories")),
+            // Tasks
+            Map.entry("createUserTask", List.of("tasks")),
+            Map.entry("editUserTask", List.of("tasks")),
+            Map.entry("deleteUserTask", List.of("tasks")),
+            // Goals (complete awards XP -> perfil; increase/decrease don't)
+            Map.entry("createUserGoal", List.of("goals")),
+            Map.entry("editUserGoal", List.of("goals")),
+            Map.entry("deleteUserGoal", List.of("goals")),
+            Map.entry("completeUserGoal", List.of("goals", "perfil")),
+            Map.entry("increaseUserGoalValue", List.of("goals")),
+            Map.entry("decreaseUserGoalValue", List.of("goals")),
+            // Routines
+            Map.entry("createUserRoutine", List.of("routines")),
+            Map.entry("editUserRoutine", List.of("routines")),
+            Map.entry("deleteUserRoutine", List.of("routines", "schedules")),
+            Map.entry("addTaskToRoutineSection", List.of("routines")),
+            Map.entry("addHabitToRoutineSection", List.of("routines")),
+            Map.entry("removeRoutineItem", List.of("routines")),
+            // Check-in (check awards XP -> perfil; skip only marks the item)
+            Map.entry("checkRoutineItem", List.of("routines", "perfil")),
+            Map.entry("skipRoutineItem", List.of("routines")),
+            // Schedules
+            Map.entry("createUserSchedule", List.of("schedules")),
+            Map.entry("updateUserSchedule", List.of("schedules")),
+            Map.entry("deleteUserSchedule", List.of("schedules")),
+            // Configuration
+            Map.entry("updateUserConfiguration", List.of("perfil")));
+
+    private AgentToolDomains() {}
+
+    public static List<String> domainsOf(String toolName) {
+        return WRITE_TOOLS.getOrDefault(toolName, List.of());
+    }
+}

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AgentToolDomains.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AgentToolDomains.java
@@ -34,17 +34,17 @@ public final class AgentToolDomains {
             // Routines
             Map.entry("createUserRoutine", List.of("routines")),
             Map.entry("editUserRoutine", List.of("routines")),
-            Map.entry("deleteUserRoutine", List.of("routines", "schedules")),
+            Map.entry("deleteUserRoutine", List.of("routines")),
             Map.entry("addTaskToRoutineSection", List.of("routines")),
             Map.entry("addHabitToRoutineSection", List.of("routines")),
             Map.entry("removeRoutineItem", List.of("routines")),
             // Check-in (check awards XP -> perfil; skip only marks the item)
             Map.entry("checkRoutineItem", List.of("routines", "perfil")),
             Map.entry("skipRoutineItem", List.of("routines")),
-            // Schedules
-            Map.entry("createUserSchedule", List.of("schedules")),
-            Map.entry("updateUserSchedule", List.of("schedules")),
-            Map.entry("deleteUserSchedule", List.of("schedules")),
+            // Schedules live inside routines on the client — no separate slice.
+            Map.entry("createUserSchedule", List.of("routines")),
+            Map.entry("updateUserSchedule", List.of("routines")),
+            Map.entry("deleteUserSchedule", List.of("routines")),
             // Configuration
             Map.entry("updateUserConfiguration", List.of("perfil")));
 

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AgentTurnBuilder.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AgentTurnBuilder.java
@@ -1,0 +1,49 @@
+package beyou.beyouapp.backend.domain.aiAgent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentSegment;
+import beyou.beyouapp.backend.domain.aiAgent.dto.AgentEvent;
+
+/**
+ * Turns the ordered event stream into a structured transcript. Every event
+ * (tokens via the Flux, tools via MeteredToolCallback) passes through the same
+ * send consumer in causal order — the stream suspends while a tool runs — so
+ * observing here yields text interleaved with the tools exactly as they happened.
+ * Only finished tools are recorded; "started" is a live-only affordance.
+ */
+class AgentTurnBuilder {
+
+    private final List<AgentSegment> segments = new ArrayList<>();
+    private final StringBuilder text = new StringBuilder();
+
+    @SuppressWarnings("unchecked")
+    void observe(AgentEvent event) {
+        switch (event.type()) {
+            case "token" -> text.append(String.valueOf(event.data().getOrDefault("text", "")));
+            case "tool" -> {
+                if ("finished".equals(event.data().get("status"))) {
+                    flushText();
+                    segments.add(AgentSegment.tool(
+                            (String) event.data().get("tool"),
+                            (String) event.data().get("error"),
+                            (List<String>) event.data().get("domains")));
+                }
+            }
+            default -> { /* done/error are not part of the transcript */ }
+        }
+    }
+
+    private void flushText() {
+        if (text.length() > 0) {
+            segments.add(AgentSegment.text(text.toString()));
+            text.setLength(0);
+        }
+    }
+
+    List<AgentSegment> build() {
+        flushText();
+        return List.copyOf(segments);
+    }
+}

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AiAgentService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AiAgentService.java
@@ -6,6 +6,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.springframework.ai.chat.client.ChatClient;
@@ -36,11 +40,24 @@ import reactor.core.publisher.Flux;
 @Slf4j
 public class AiAgentService {
 
+    /** SSE comment sent on this cadence keeps idle connections alive through
+     *  proxies while the agent thinks or runs a slow tool. */
+    private static final long HEARTBEAT_SECONDS = 15;
+
     private final ChatClient chatClient;
     private final ChatService chatService;
     private final AgentMessageService agentMessageService;
     private final Object[] toolCallbacks;
     private final Resource systemTemplate;
+
+    // ponytail: one daemon thread — pings are trivial writes; bump the pool
+    // only if heartbeat latency across many concurrent streams ever shows up.
+    private final ScheduledExecutorService heartbeatScheduler =
+            Executors.newSingleThreadScheduledExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "agent-sse-heartbeat");
+                thread.setDaemon(true);
+                return thread;
+            });
 
     public AiAgentService(DeepSeekChatModel chatModel,
             ChatMemory chatMemory,
@@ -80,18 +97,24 @@ public class AiAgentService {
 
         SseEmitter emitter = new SseEmitter(180_000L);
 
+        // The heartbeat thread and the reactor thread both write to this one
+        // emitter — serialize every write so events never interleave mid-frame.
+        Object streamLock = new Object();
+
         // Every event flows through here in causal order (tokens from the Flux,
         // tools from MeteredToolCallback). The builder observes FIRST, so a
         // dead client (send throwing) never costs us the persisted transcript.
         AgentTurnBuilder turn = new AgentTurnBuilder();
         Consumer<AgentEvent> send = event -> {
             turn.observe(event);
-            try {
-                emitter.send(SseEmitter.event()
-                        .name(event.type())
-                        .data(event.data(), MediaType.APPLICATION_JSON));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            synchronized (streamLock) {
+                try {
+                    emitter.send(SseEmitter.event()
+                            .name(event.type())
+                            .data(event.data(), MediaType.APPLICATION_JSON));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         };
 
@@ -127,8 +150,24 @@ public class AiAgentService {
                     }
                 });
 
-        emitter.onTimeout(subscription::dispose);
-        emitter.onCompletion(subscription::dispose);
+        // Heartbeat: also the ONLY dead-client detector during quiet pauses
+        // (no token send to fail on) — its failure aborts the stream.
+        ScheduledFuture<?> heartbeat = heartbeatScheduler.scheduleAtFixedRate(() -> {
+            synchronized (streamLock) {
+                try {
+                    emitter.send(SseEmitter.event().comment("ping"));
+                } catch (Exception e) {
+                    emitter.complete(); // -> onCompletion cancels heartbeat + disposes
+                }
+            }
+        }, HEARTBEAT_SECONDS, HEARTBEAT_SECONDS, TimeUnit.SECONDS);
+
+        Runnable cleanup = () -> {
+            heartbeat.cancel(false);
+            subscription.dispose();
+        };
+        emitter.onTimeout(cleanup);
+        emitter.onCompletion(cleanup);
 
         return emitter;
     }

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AiAgentService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AiAgentService.java
@@ -20,9 +20,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import beyou.beyouapp.backend.domain.ai.AiIconCatalog;
+import beyou.beyouapp.backend.domain.aiAgent.chat.AgentMessageService;
 import beyou.beyouapp.backend.domain.aiAgent.chat.Chat;
 import beyou.beyouapp.backend.domain.aiAgent.chat.ChatService;
-import beyou.beyouapp.backend.domain.aiAgent.chat.dto.ChatMessageDTO;
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentMessageDTO;
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentSegment;
 import beyou.beyouapp.backend.domain.aiAgent.dto.AgentEvent;
 import beyou.beyouapp.backend.user.User;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -35,19 +37,20 @@ import reactor.core.publisher.Flux;
 public class AiAgentService {
 
     private final ChatClient chatClient;
-    private final ChatMemory chatMemory;
     private final ChatService chatService;
+    private final AgentMessageService agentMessageService;
     private final Object[] toolCallbacks;
     private final Resource systemTemplate;
 
     public AiAgentService(DeepSeekChatModel chatModel,
             ChatMemory chatMemory,
             ChatService chatService,
+            AgentMessageService agentMessageService,
             Tools tools,
             MeterRegistry meterRegistry,
             @Value("classpath:/prompts/aiAgent.st") Resource systemTemplate) {
-        this.chatMemory = chatMemory;
         this.chatService = chatService;
+        this.agentMessageService = agentMessageService;
         this.toolCallbacks = Arrays.stream(ToolCallbacks.from(tools))
                 .map(callback -> (Object) new MeteredToolCallback(callback, meterRegistry))
                 .toArray();
@@ -64,6 +67,9 @@ public class AiAgentService {
                 .call()
                 .content();
 
+        // Non-streaming path (mobile): no ordered tool capture, so the transcript
+        // is text-only. Interleaved tool segments arrive once mobile streams too.
+        agentMessageService.recordTurn(chatId, userInput, List.of(AgentSegment.text(reply)));
         // Reload-by-id: tools may have re-saved the chat during the call above.
         chatService.touch(chatId, userId);
         return reply;
@@ -74,7 +80,12 @@ public class AiAgentService {
 
         SseEmitter emitter = new SseEmitter(180_000L);
 
+        // Every event flows through here in causal order (tokens from the Flux,
+        // tools from MeteredToolCallback). The builder observes FIRST, so a
+        // dead client (send throwing) never costs us the persisted transcript.
+        AgentTurnBuilder turn = new AgentTurnBuilder();
         Consumer<AgentEvent> send = event -> {
+            turn.observe(event);
             try {
                 emitter.send(SseEmitter.event()
                         .name(event.type())
@@ -88,12 +99,8 @@ public class AiAgentService {
                 .stream()
                 .content();
 
-        StringBuilder fullReply = new StringBuilder();
         Disposable subscription = tokens.subscribe(
-                token -> {
-                    fullReply.append(token);
-                    send.accept(AgentEvent.token(token));
-                },
+                token -> send.accept(AgentEvent.token(token)),
                 error -> {
                     log.error("Error on agent stream subscription -> {}", error.getMessage(), error);
                     try {
@@ -105,14 +112,17 @@ public class AiAgentService {
                     }
                 },
                 () -> {
-                    try{
-                        String response = fullReply.toString();
-                        send.accept(AgentEvent.done(response));
-                    }catch(RuntimeException e){
+                    List<AgentSegment> segments = turn.build();
+                    try {
+                        agentMessageService.recordTurn(chatId, userInput, segments);
+                        send.accept(AgentEvent.done(segments));
+                    } catch (RuntimeException e) {
                         log.error("Error trying to emit complete... {}", e.getClass().getSimpleName(), e);
-                    }finally{
+                    } finally {
                         emitter.complete();
-                        // Blocking call inside a event loop thread, hope will never cause a problem, move to publishOn(Schedulers.boundedElastic()) if stream latency ever spikes
+                        // Blocking JPA call on the netty event loop — fine at
+                        // our volume, move to publishOn(Schedulers.boundedElastic()) if
+                        // stream latency ever spikes.
                         chatService.touch(chatId, userId);
                     }
                 });
@@ -121,7 +131,6 @@ public class AiAgentService {
         emitter.onCompletion(subscription::dispose);
 
         return emitter;
-
     }
 
     private ChatClient.ChatClientRequestSpec buildPrompt(Chat chat, String userInput, String currentPage, Map<String, Object> toolContext) {
@@ -140,12 +149,10 @@ public class AiAgentService {
             .toolContext(toolContext);
     }
 
-    /** Window-limited history (the model's working memory), oldest first. */
-    public List<ChatMessageDTO> getMessages(UUID chatId, UUID userId) {
-        Chat chat = chatService.getChat(chatId, userId);
-        return chatMemory.get(chat.getId().toString()).stream()
-                .map(message -> new ChatMessageDTO(message.getMessageType().name(), message.getText()))
-                .toList();
+    /** Full display transcript, oldest first (ownership checked here). */
+    public List<AgentMessageDTO> getMessages(UUID chatId, UUID userId) {
+        chatService.getChat(chatId, userId);
+        return agentMessageService.getMessages(chatId);
     }
 
     private String orNone(String value) {

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AiAgentService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AiAgentService.java
@@ -6,10 +6,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import org.springframework.ai.chat.client.ChatClient;
@@ -44,20 +47,29 @@ public class AiAgentService {
      *  proxies while the agent thinks or runs a slow tool. */
     private static final long HEARTBEAT_SECONDS = 15;
 
+    /** Concurrent live streams per user (two tabs = 2). Caps LLM cost/resource abuse. */
+    private static final int MAX_CONCURRENT_STREAMS_PER_USER = 2;
+
     private final ChatClient chatClient;
     private final ChatService chatService;
     private final AgentMessageService agentMessageService;
     private final Object[] toolCallbacks;
     private final Resource systemTemplate;
 
-    // ponytail: one daemon thread — pings are trivial writes; bump the pool
-    // only if heartbeat latency across many concurrent streams ever shows up.
+    // emitter.send() is BLOCKING: a stalled client applies TCP backpressure and
+    // holds its scheduler thread until the emitter times out. A pool bounds the
+    // blast radius (one stalled client can't starve every other stream's ping);
+    // combined with the per-user stream cap, total concurrent streams are bounded.
     private final ScheduledExecutorService heartbeatScheduler =
-            Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Executors.newScheduledThreadPool(Math.max(4, Runtime.getRuntime().availableProcessors()), runnable -> {
                 Thread thread = new Thread(runnable, "agent-sse-heartbeat");
                 thread.setDaemon(true);
                 return thread;
             });
+
+    // Per-user count of in-flight streams. Entries are tiny and bounded by the
+    // active-user set, so they're left in place rather than pruned on zero.
+    private final ConcurrentMap<UUID, AtomicInteger> activeStreams = new ConcurrentHashMap<>();
 
     public AiAgentService(DeepSeekChatModel chatModel,
             ChatMemory chatMemory,
@@ -95,6 +107,22 @@ public class AiAgentService {
     public SseEmitter streamMessage(UUID chatId, String userInput, UUID userId, String currentPage) {
         Chat chat = chatService.getChat(chatId, userId);
 
+        // Per-user concurrency cap: reject a new stream cleanly (one parseable
+        // error event) instead of opening an unbounded number of LLM calls.
+        AtomicInteger userStreams = activeStreams.computeIfAbsent(userId, k -> new AtomicInteger());
+        if (userStreams.incrementAndGet() > MAX_CONCURRENT_STREAMS_PER_USER) {
+            userStreams.decrementAndGet();
+            SseEmitter rejected = new SseEmitter(5_000L);
+            try {
+                AgentEvent event = AgentEvent.error("TOO_MANY_STREAMS");
+                rejected.send(SseEmitter.event().name(event.type()).data(event.data(), MediaType.APPLICATION_JSON));
+            } catch (IOException ignored) {
+                // client already gone — nothing to deliver
+            }
+            rejected.complete();
+            return rejected;
+        }
+
         SseEmitter emitter = new SseEmitter(180_000L);
 
         // The heartbeat thread and the reactor thread both write to this one
@@ -126,19 +154,29 @@ public class AiAgentService {
                 token -> send.accept(AgentEvent.token(token)),
                 error -> {
                     log.error("Error on agent stream subscription -> {}", error.getMessage(), error);
+                    // Tool side-effects already committed; persist the partial turn
+                    // (if anything streamed) so history isn't lost, THEN report error.
+                    persistTurnSafely(chatId, userInput, turn.build());
                     try {
                         send.accept(AgentEvent.error(error.getClass().getSimpleName()));
                     } catch (RuntimeException e) {
                         log.error("Error trying to emit error... {}", e.getClass().getSimpleName(), e);
                     } finally {
                         emitter.complete();
+                        chatService.touch(chatId, userId);
                     }
                 },
                 () -> {
                     List<AgentSegment> segments = turn.build();
+                    // Persist FIRST: only emit done if the transcript is safe.
+                    // If persistence fails, the client must learn it failed rather
+                    // than get a clean close with committed tool side-effects but
+                    // no chat record — so emit an error event instead of done.
+                    boolean persisted = persistTurnSafely(chatId, userInput, segments);
                     try {
-                        agentMessageService.recordTurn(chatId, userInput, segments);
-                        send.accept(AgentEvent.done(segments));
+                        send.accept(persisted
+                                ? AgentEvent.done(segments)
+                                : AgentEvent.error("TRANSCRIPT_PERSIST_FAILED"));
                     } catch (RuntimeException e) {
                         log.error("Error trying to emit complete... {}", e.getClass().getSimpleName(), e);
                     } finally {
@@ -162,14 +200,30 @@ public class AiAgentService {
             }
         }, HEARTBEAT_SECONDS, HEARTBEAT_SECONDS, TimeUnit.SECONDS);
 
+        // onCompletion fires exactly once for any terminal state (complete,
+        // error, timeout), so the stream slot is always released.
         Runnable cleanup = () -> {
             heartbeat.cancel(false);
             subscription.dispose();
+            userStreams.decrementAndGet();
         };
         emitter.onTimeout(cleanup);
         emitter.onCompletion(cleanup);
 
         return emitter;
+    }
+
+    /** Persist a turn without letting a DB failure escape; returns whether it stuck.
+     *  Empty segments (nothing streamed before an early error) are skipped. */
+    private boolean persistTurnSafely(UUID chatId, String userInput, List<AgentSegment> segments) {
+        if (segments.isEmpty()) return false;
+        try {
+            agentMessageService.recordTurn(chatId, userInput, segments);
+            return true;
+        } catch (RuntimeException e) {
+            log.error("Failed to persist agent transcript for chat {}", chatId, e);
+            return false;
+        }
     }
 
     private ChatClient.ChatClientRequestSpec buildPrompt(Chat chat, String userInput, String currentPage, Map<String, Object> toolContext) {

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AiAgentService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/AiAgentService.java
@@ -1,10 +1,12 @@
 package beyou.beyouapp.backend.domain.aiAgent;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
@@ -13,16 +15,23 @@ import org.springframework.ai.deepseek.DeepSeekChatModel;
 import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import beyou.beyouapp.backend.domain.ai.AiIconCatalog;
 import beyou.beyouapp.backend.domain.aiAgent.chat.Chat;
 import beyou.beyouapp.backend.domain.aiAgent.chat.ChatService;
 import beyou.beyouapp.backend.domain.aiAgent.chat.dto.ChatMessageDTO;
+import beyou.beyouapp.backend.domain.aiAgent.dto.AgentEvent;
 import beyou.beyouapp.backend.user.User;
 import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
 
 @Service
+@Slf4j
 public class AiAgentService {
 
     private final ChatClient chatClient;
@@ -39,8 +48,6 @@ public class AiAgentService {
             @Value("classpath:/prompts/aiAgent.st") Resource systemTemplate) {
         this.chatMemory = chatMemory;
         this.chatService = chatService;
-        // Metered wrappers feed the beyou.ai.tool timer on the Grafana AI dashboard.
-        // tools(Object...) dispatches ToolCallback instances directly (2.0 unified API).
         this.toolCallbacks = Arrays.stream(ToolCallbacks.from(tools))
                 .map(callback -> (Object) new MeteredToolCallback(callback, meterRegistry))
                 .toArray();
@@ -52,26 +59,85 @@ public class AiAgentService {
 
     public String processMessage(UUID chatId, String userInput, UUID userId, String currentPage) {
         Chat chat = chatService.getChat(chatId, userId);
-        User user = chat.getUser();
 
-        String reply = this.chatClient.prompt()
-                .system(s -> s.text(systemTemplate)
-                        .param("language", user.getLanguageInUse() != null ? user.getLanguageInUse() : "en")
-                        .param("iconCatalog", AiIconCatalog.promptCatalog())
-                        .param("userContext", orNone(user.getUserContext()))
-                        .param("userChatContext", orNone(chat.getUserContextInChat()))
-                        .param("currentPage", orNone(currentPage))
-                        .param("today", LocalDate.now().toString()))
-                .user(userInput)
-                .advisors(a -> a.param(ChatMemory.CONVERSATION_ID, chat.getId().toString()))
-                .tools(toolCallbacks)
-                .toolContext(Map.of("userId", userId, "chatId", chatId))
+        String reply = buildPrompt(chat, userInput, currentPage, Map.of("userId", userId, "chatId", chatId))
                 .call()
                 .content();
 
         // Reload-by-id: tools may have re-saved the chat during the call above.
         chatService.touch(chatId, userId);
         return reply;
+    }
+
+    public SseEmitter streamMessage(UUID chatId, String userInput, UUID userId, String currentPage) {
+        Chat chat = chatService.getChat(chatId, userId);
+
+        SseEmitter emitter = new SseEmitter(180_000L);
+
+        Consumer<AgentEvent> send = event -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name(event.type())
+                        .data(event.data(), MediaType.APPLICATION_JSON));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        Flux<String> tokens = buildPrompt(chat, userInput, currentPage, Map.of("userId", userId, "chatId", chatId, MeteredToolCallback.EVENTS_KEY, send))
+                .stream()
+                .content();
+
+        StringBuilder fullReply = new StringBuilder();
+        Disposable subscription = tokens.subscribe(
+                token -> {
+                    fullReply.append(token);
+                    send.accept(AgentEvent.token(token));
+                },
+                error -> {
+                    log.error("Error on agent stream subscription -> {}", error.getMessage(), error);
+                    try {
+                        send.accept(AgentEvent.error(error.getClass().getSimpleName()));
+                    } catch (RuntimeException e) {
+                        log.error("Error trying to emit error... {}", e.getClass().getSimpleName(), e);
+                    } finally {
+                        emitter.complete();
+                    }
+                },
+                () -> {
+                    try{
+                        String response = fullReply.toString();
+                        send.accept(AgentEvent.done(response));
+                    }catch(RuntimeException e){
+                        log.error("Error trying to emit complete... {}", e.getClass().getSimpleName(), e);
+                    }finally{
+                        emitter.complete();
+                        // Blocking call inside a event loop thread, hope will never cause a problem, move to publishOn(Schedulers.boundedElastic()) if stream latency ever spikes
+                        chatService.touch(chatId, userId);
+                    }
+                });
+
+        emitter.onTimeout(subscription::dispose);
+        emitter.onCompletion(subscription::dispose);
+
+        return emitter;
+
+    }
+
+    private ChatClient.ChatClientRequestSpec buildPrompt(Chat chat, String userInput, String currentPage, Map<String, Object> toolContext) {
+        User user = chat.getUser();
+        return this.chatClient.prompt()
+            .system(s -> s.text(systemTemplate)
+                .param("language", user.getLanguageInUse() != null ? user.getLanguageInUse() : "en")
+                .param("iconCatalog", AiIconCatalog.promptCatalog())
+                .param("userContext", orNone(user.getUserContext()))
+                .param("userChatContext", orNone(chat.getUserContextInChat()))
+                .param("currentPage", orNone(currentPage))
+                .param("today", LocalDate.now().toString()))
+            .user(userInput)
+            .advisors(a -> a.param(ChatMemory.CONVERSATION_ID, chat.getId().toString()))
+            .tools(toolCallbacks)
+            .toolContext(toolContext);
     }
 
     /** Window-limited history (the model's working memory), oldest first. */

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/MeteredToolCallback.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/MeteredToolCallback.java
@@ -1,12 +1,16 @@
 package beyou.beyouapp.backend.domain.aiAgent;
 
+import java.util.function.Consumer;
+
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.metadata.ToolMetadata;
 
+import beyou.beyouapp.backend.domain.aiAgent.dto.AgentEvent;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Times every agent tool execution as `beyou.ai.tool` (tags: tool, error).
@@ -14,9 +18,11 @@ import io.micrometer.core.instrument.Timer;
  * on the method-tools path, so we own the metric at the callback boundary —
  * the same hook a future streaming "agent is working" event will use.
  */
+@Slf4j
 public class MeteredToolCallback implements ToolCallback {
 
     public static final String METRIC_NAME = "beyou.ai.tool";
+    public static final String EVENTS_KEY = "agentEvents";
 
     private final ToolCallback delegate;
     private final MeterRegistry meterRegistry;
@@ -43,7 +49,36 @@ public class MeteredToolCallback implements ToolCallback {
 
     @Override
     public String call(String toolInput, ToolContext toolContext) {
-        return timed(() -> delegate.call(toolInput, toolContext));
+        Consumer<AgentEvent> events = eventsFrom(toolContext);
+        String name = delegate.getToolDefinition().name();
+
+        try{
+            emit(events, AgentEvent.toolStarted(name));
+            String timedResult = timed(() -> delegate.call(toolInput, toolContext));
+            
+            emit(events, AgentEvent.toolFinished(name, null, AgentToolDomains.domainsOf(name)));
+            
+            return timedResult;
+        }catch(RuntimeException e){
+            emit(events, AgentEvent.toolFinished(name, e.getClass().getSimpleName(), AgentToolDomains.domainsOf(name)));
+            throw e;
+        }
+    }
+
+    private void emit(Consumer<AgentEvent> events, AgentEvent event){
+        if(events == null) return;
+
+        try{
+            events.accept(event);
+        }catch(RuntimeException e){
+            log.error("Error on send event {}", e.getMessage(), e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Consumer<AgentEvent> eventsFrom(ToolContext toolContext){
+        if(toolContext == null) return null;
+        return (Consumer<AgentEvent>) toolContext.getContext().get(EVENTS_KEY);
     }
 
     private String timed(java.util.function.Supplier<String> execution) {

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessage.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessage.java
@@ -1,0 +1,60 @@
+package beyou.beyouapp.backend.domain.aiAgent.chat;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * One display-history row for an agent chat. Cascade delete is owned by the DB
+ * FK (V7), so there's no JPA relationship to the Chat — just the id.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "agent_message")
+public class AgentMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "chat_id", nullable = false)
+    private UUID chatId;
+
+    @Column(nullable = false, length = 10)
+    private String role;
+
+    /** JSON array of AgentSegment — the ordered transcript of this turn. */
+    @Column(nullable = false, columnDefinition = "text")
+    private String content;
+
+    @Column(name = "sequence_id", nullable = false)
+    private long sequenceId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public AgentMessage(UUID chatId, String role, String content, long sequenceId) {
+        this.chatId = chatId;
+        this.role = role;
+        this.content = content;
+        this.sequenceId = sequenceId;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessageRepository.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessageRepository.java
@@ -4,8 +4,18 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AgentMessageRepository extends JpaRepository<AgentMessage, UUID> {
     List<AgentMessage> findByChatIdOrderBySequenceIdAsc(UUID chatId);
     long countByChatId(UUID chatId);
+
+    /**
+     * Serializes transcript writes for one chat across concurrent turns (two
+     * tabs, double-submit, retry overlap) so sequence assignment stays atomic.
+     * Transaction-scoped: released on commit/rollback. Different chats don't block.
+     */
+    @Query(value = "SELECT pg_advisory_xact_lock(hashtext(:chatId))", nativeQuery = true)
+    void lockChatForTranscript(@Param("chatId") String chatId);
 }

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessageRepository.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessageRepository.java
@@ -1,0 +1,11 @@
+package beyou.beyouapp.backend.domain.aiAgent.chat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AgentMessageRepository extends JpaRepository<AgentMessage, UUID> {
+    List<AgentMessage> findByChatIdOrderBySequenceIdAsc(UUID chatId);
+    long countByChatId(UUID chatId);
+}

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessageService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessageService.java
@@ -37,6 +37,9 @@ public class AgentMessageService {
     /** Persist one user->assistant exchange as two ordered rows. */
     @Transactional
     public void recordTurn(UUID chatId, String userInput, List<AgentSegment> assistantSegments) {
+        // Lock this chat's transcript writes so concurrent turns can't read the
+        // same count and assign duplicate sequence ids (uq constraint is the backstop).
+        agentMessageRepository.lockChatForTranscript(chatId.toString());
         long seq = agentMessageRepository.countByChatId(chatId);
         agentMessageRepository.save(new AgentMessage(
                 chatId, USER, toJson(List.of(AgentSegment.text(userInput))), seq));

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessageService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/AgentMessageService.java
@@ -1,0 +1,85 @@
+package beyou.beyouapp.backend.domain.aiAgent.chat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentMessageDTO;
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentSegment;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Owns the display transcript (agent_message): persists each turn as ordered
+ * segments and reads it back for the UI. Falls back to the Spring AI memory
+ * (text-only) for chats created before this table existed.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AgentMessageService {
+
+    private static final String USER = "USER";
+    private static final String ASSISTANT = "ASSISTANT";
+    private static final List<String> VISIBLE_MEMORY_ROLES = List.of("USER", "ASSISTANT");
+
+    private final AgentMessageRepository agentMessageRepository;
+    private final ChatMemory chatMemory;
+    private final ObjectMapper objectMapper;
+
+    /** Persist one user->assistant exchange as two ordered rows. */
+    @Transactional
+    public void recordTurn(UUID chatId, String userInput, List<AgentSegment> assistantSegments) {
+        long seq = agentMessageRepository.countByChatId(chatId);
+        agentMessageRepository.save(new AgentMessage(
+                chatId, USER, toJson(List.of(AgentSegment.text(userInput))), seq));
+        agentMessageRepository.save(new AgentMessage(
+                chatId, ASSISTANT, toJson(assistantSegments), seq + 1));
+    }
+
+    @Transactional(readOnly = true)
+    public List<AgentMessageDTO> getMessages(UUID chatId) {
+        List<AgentMessage> stored = agentMessageRepository.findByChatIdOrderBySequenceIdAsc(chatId);
+        if (!stored.isEmpty()) {
+            return stored.stream()
+                    .map(m -> new AgentMessageDTO(m.getRole(), fromJson(m.getContent())))
+                    .toList();
+        }
+        return legacyFromMemory(chatId);
+    }
+
+    /** Chats created before agent_message existed: text-only, from model memory. */
+    private List<AgentMessageDTO> legacyFromMemory(UUID chatId) {
+        return chatMemory.get(chatId.toString()).stream()
+                .filter(m -> VISIBLE_MEMORY_ROLES.contains(m.getMessageType().name()))
+                .map(m -> new AgentMessageDTO(
+                        m.getMessageType() == MessageType.USER ? USER : ASSISTANT,
+                        List.of(AgentSegment.text(m.getText()))))
+                .toList();
+    }
+
+    private String toJson(List<AgentSegment> segments) {
+        try {
+            return objectMapper.writeValueAsString(segments);
+        } catch (Exception e) {
+            log.error("Failed to serialize agent segments for chat", e);
+            return "[]";
+        }
+    }
+
+    private List<AgentSegment> fromJson(String json) {
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<AgentSegment>>() {});
+        } catch (Exception e) {
+            log.error("Failed to deserialize agent segments", e);
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/dto/AgentMessageDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/dto/AgentMessageDTO.java
@@ -1,0 +1,7 @@
+package beyou.beyouapp.backend.domain.aiAgent.chat.dto;
+
+import java.util.List;
+
+/** One rendered turn: USER or ASSISTANT, as an ordered list of segments. */
+public record AgentMessageDTO(String role, List<AgentSegment> segments) {
+}

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/dto/AgentSegment.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/dto/AgentSegment.java
@@ -1,0 +1,29 @@
+package beyou.beyouapp.backend.domain.aiAgent.chat.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * One piece of an assistant turn: either a run of text or a single tool the
+ * agent used. Ordered lists of these ARE the display transcript — same shape
+ * on the wire (done event), persisted in agent_message.content, and rendered.
+ * Null fields are dropped from JSON so each segment only carries its own kind.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AgentSegment(
+        String type,
+        String text,
+        String tool,
+        /** null = success; the frontend keys its red/green state on presence. */
+        String error,
+        List<String> domains) {
+
+    public static AgentSegment text(String text) {
+        return new AgentSegment("text", text, null, null, null);
+    }
+
+    public static AgentSegment tool(String tool, String error, List<String> domains) {
+        return new AgentSegment("tool", null, tool, error, domains);
+    }
+}

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/dto/ChatMessageDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/dto/ChatMessageDTO.java
@@ -1,4 +1,0 @@
-package beyou.beyouapp.backend.domain.aiAgent.chat.dto;
-
-public record ChatMessageDTO(String role, String text) {
-}

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/dto/AgentEvent.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/dto/AgentEvent.java
@@ -1,0 +1,34 @@
+package beyou.beyouapp.backend.domain.aiAgent.dto;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public record AgentEvent(
+        String type,
+        Map<String, Object> data) {
+
+    public static AgentEvent token(String text) {
+        return new AgentEvent("token", Map.of("text", text));
+    }
+
+    public static AgentEvent toolStarted(String name) {
+        return new AgentEvent("tool", Map.of("tool", name, "status", "started"));
+    }
+
+    public static AgentEvent toolFinished(String name, String error, List<String> domains) {
+        Map<String, Object> data = new HashMap<>(
+                Map.of("tool", name, "status", "finished", "domains", domains));
+        if (error != null)
+            data.put("error", error);
+        return new AgentEvent("tool", data);
+    }
+
+    public static AgentEvent done(String fullReply) {
+        return new AgentEvent("done", Map.of("done", fullReply));
+    }
+
+    public static AgentEvent error(String errorKey) {
+        return new AgentEvent("error", Map.of("error", errorKey));
+    }
+}

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/dto/AgentEvent.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/dto/AgentEvent.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentSegment;
+
 public record AgentEvent(
         String type,
         Map<String, Object> data) {
@@ -24,8 +26,9 @@ public record AgentEvent(
         return new AgentEvent("tool", data);
     }
 
-    public static AgentEvent done(String fullReply) {
-        return new AgentEvent("done", Map.of("done", fullReply));
+    /** Authoritative structured turn — the client swaps its live-built segments for this. */
+    public static AgentEvent done(List<AgentSegment> segments) {
+        return new AgentEvent("done", Map.of("segments", segments));
     }
 
     public static AgentEvent error(String errorKey) {

--- a/src/main/java/beyou/beyouapp/backend/domain/category/CategoryService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/category/CategoryService.java
@@ -12,6 +12,7 @@ import beyou.beyouapp.backend.exceptions.category.CategoryNotFound;
 import beyou.beyouapp.backend.exceptions.user.UserNotFound;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -53,6 +54,10 @@ public class CategoryService {
         return category;
     }
 
+    // Transactional so the mapper can walk lazy habits/tasks/goals relations:
+    // OSIV covers this on the request thread, but agent tools run on a
+    // boundedElastic thread.
+    @Transactional(readOnly = true)
     @Cacheable(cacheNames = "categories", key = "#userId")
     public List<CategoryResponseDTO> getAllCategories(UUID userId){
         ArrayList<Category> categories = categoryRepository.findAllByUserId(userId)

--- a/src/main/java/beyou/beyouapp/backend/domain/common/RefreshUiDtoBuilder.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/common/RefreshUiDtoBuilder.java
@@ -13,23 +13,19 @@ import beyou.beyouapp.backend.domain.common.DTO.RefreshObjectDTO;
 import beyou.beyouapp.backend.domain.common.DTO.RefreshUiDTO;
 import beyou.beyouapp.backend.domain.common.DTO.RefreshUserDTO;
 import beyou.beyouapp.backend.domain.habit.Habit;
-import beyou.beyouapp.backend.security.AuthenticatedUser;
 import beyou.beyouapp.backend.user.User;
-import beyou.beyouapp.backend.user.UserService;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class RefreshUiDtoBuilder {
 
-    private final AuthenticatedUser authenticatedUser;
-    private final UserService userService;
-
     public RefreshUiDTO buildRefreshUiDto(
             LocalDate date,
             Habit habitToRefresh,
             List<Category> categoriesToRefresh,
-            RefreshItemCheckedDTO refreshItemCheckedDTO) {
+            RefreshItemCheckedDTO refreshItemCheckedDTO,
+            User user) {
         RefreshObjectDTO habitToRefreshDto = null;
         if (habitToRefresh != null) {
             habitToRefreshDto = new RefreshObjectDTO(
@@ -53,16 +49,14 @@ public class RefreshUiDtoBuilder {
             });
         }
 
-        User userInContext = authenticatedUser.getAuthenticatedUser();
-        User freshUser = userService.findUserById(userInContext.getId());
         RefreshUserDTO refreshUserDTO = new RefreshUserDTO(
-                freshUser.getCurrentConstance(date),
-                freshUser.getCompletedDays().contains(date),
-                freshUser.getMaxConstance(),
-                freshUser.getXpProgress().getXp(),
-                freshUser.getXpProgress().getLevel(),
-                freshUser.getXpProgress().getActualLevelXp(),
-                freshUser.getXpProgress().getNextLevelXp());
+                user.getCurrentConstance(date),
+                user.getCompletedDays().contains(date),
+                user.getMaxConstance(),
+                user.getXpProgress().getXp(),
+                user.getXpProgress().getLevel(),
+                user.getXpProgress().getActualLevelXp(),
+                user.getXpProgress().getNextLevelXp());
 
         return new RefreshUiDTO(
                 refreshUserDTO,

--- a/src/main/java/beyou/beyouapp/backend/domain/common/XpCalculatorService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/common/XpCalculatorService.java
@@ -15,7 +15,6 @@ import beyou.beyouapp.backend.domain.habit.Habit;
 import beyou.beyouapp.backend.domain.habit.HabitRepository;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutine;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutineRepository;
-import beyou.beyouapp.backend.security.AuthenticatedUser;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserRepository;
 import lombok.AllArgsConstructor;
@@ -28,58 +27,29 @@ import lombok.extern.slf4j.Slf4j;
 public class XpCalculatorService {
 
     private final XpByLevelRepository xpByLevelRepository;
-    private final AuthenticatedUser authenticatedUser;
     private final UserRepository userRepository;
     private final DiaryRoutineRepository diaryRoutineRepository;
     private final HabitRepository habitRepository;
     private final CategoryRepository categoryRepository;
     private final GoalRepository goalRepository;
 
-    public void addXpToUserRoutineHabitAndCategoriesAndPersist(Double newXp, DiaryRoutine routine, Habit habit,
-            List<Category> categories) {
-        addUserXpAndPersist(newXp);
-        addRoutineXpAndPersist(newXp, routine);
-        addHabitXpAndPersist(newXp, habit);
-        addCategoriesXpAndPersist(newXp, categories);
-    }
+    // XP always flows through the User-explicit methods below: identity travels
+    // with the data, never from SecurityContextHolder (a ThreadLocal that isn't
+    // present on the agent's boundedElastic tool-execution thread).
 
-    public void addXpToUserRoutineAndCategoriesAndPersist(Double newXp, DiaryRoutine routine,
+    public void addXpToUserGoalAndCategoriesAndPersist(User user, Double newXp, Goal goal,
             List<Category> categories) {
-        addUserXpAndPersist(newXp);
-        addRoutineXpAndPersist(newXp, routine);
-        addCategoriesXpAndPersist(newXp, categories);
-    }
-
-    public void addXpToUserGoalAndCategoriesAndPersist(Double newXp, Goal goal,
-            List<Category> categories) {
-        addUserXpAndPersist(newXp);
+        addUserXpAndPersist(user, newXp);
         addGoalXpAndPersist(newXp, goal);
         addCategoriesXpAndPersist(newXp, categories);
     }
 
-    public void removeXpOfUserRoutineHabitAndCategoriesAndPersist(Double xpToRemove, DiaryRoutine routine, Habit habit,
+    public void removeXpOfUserGoalAndCategoriesAndPersist(User user, Double newXp, Goal goal,
             List<Category> categories) {
-        removeUserXpAndPersist(xpToRemove);
-        removeRoutineXpAndPersist(xpToRemove, routine);
-        removeHabitXpAndPersist(xpToRemove, habit);
-        removeCategoriesXpAndPersist(xpToRemove, categories);
-    }
-
-    public void removeXpOfUserRoutineAndCategoriesAndPersist(Double xpToRemove, DiaryRoutine routine,
-            List<Category> categories) {
-        removeUserXpAndPersist(xpToRemove);
-        removeRoutineXpAndPersist(xpToRemove, routine);
-        removeCategoriesXpAndPersist(xpToRemove, categories);
-    }
-
-    public void removeXpOfUserGoalAndCategoriesAndPersist(Double newXp, Goal goal,
-            List<Category> categories) {
-        removeUserXpAndPersist(newXp);
+        removeUserXpAndPersist(user, newXp);
         removeGoalXpAndPersist(goal);
         removeCategoriesXpAndPersist(newXp, categories);
     }
-
-    // === Snapshot-compatible overloads (accept User directly, no SecurityContext needed) ===
 
     public void addXpToUserRoutineHabitAndCategoriesAndPersist(User user, Double newXp, DiaryRoutine routine,
             Habit habit, List<Category> categories) {
@@ -127,20 +97,6 @@ public class XpCalculatorService {
 
     public void removeXpFromUserOnly(User user, Double xpToRemove) {
         removeUserXpAndPersist(user, xpToRemove);
-    }
-
-    private void addUserXpAndPersist(Double newXp) {
-        User user = authenticatedUser.getAuthenticatedUser();
-        user.getXpProgress().addXp(
-                newXp,
-                level -> xpByLevelRepository.findByLevel(level));
-
-        try {
-            userRepository.save(user);
-        } catch (Exception e) {
-            log.error("ERROR ADDING XP TO USER -> {}", e.getMessage());
-            throw e;
-        }
     }
 
     private void addUserXpAndPersist(User user, Double newXp) {
@@ -214,20 +170,6 @@ public class XpCalculatorService {
             goalRepository.save(goal);
         } catch (Exception e) {
             log.error("ERROR REMOVING XP TO GOAL -> {}", e.getMessage());
-            throw e;
-        }
-    }
-
-    private void removeUserXpAndPersist(Double xpToRemove) {
-        User user = authenticatedUser.getAuthenticatedUser();
-        user.getXpProgress().removeXp(
-                xpToRemove,
-                level -> xpByLevelRepository.findByLevel(level));
-
-        try {
-            userRepository.save(user);
-        } catch (Exception e) {
-            log.error("ERROR REMOVING XP FROM USER -> {}", e.getMessage());
             throw e;
         }
     }

--- a/src/main/java/beyou/beyouapp/backend/domain/goal/GoalService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/goal/GoalService.java
@@ -132,7 +132,8 @@ public class GoalService {
             LocalDate.now(),
             null,
             goal.getCategories(),
-            null
+            null,
+            goal.getUser()
         );
     }
 
@@ -141,7 +142,7 @@ public class GoalService {
         goal.setStatus(GoalStatus.COMPLETED);
         goal.setCompleteDate(LocalDate.now());
 
-        xpCalculatorService.addXpToUserGoalAndCategoriesAndPersist(xpReward, goal, goal.getCategories());
+        xpCalculatorService.addXpToUserGoalAndCategoriesAndPersist(goal.getUser(), xpReward, goal, goal.getCategories());
     }
 
     private void removeCompletedOfAGoalAndRemoveXp(Goal goal, double xpReward){
@@ -149,7 +150,7 @@ public class GoalService {
         goal.setStatus(GoalStatus.IN_PROGRESS);
         goal.setCompleteDate(null);
 
-        xpCalculatorService.removeXpOfUserGoalAndCategoriesAndPersist(xpReward, goal, goal.getCategories());
+        xpCalculatorService.removeXpOfUserGoalAndCategoriesAndPersist(goal.getUser(), xpReward, goal, goal.getCategories());
     }
 
     public GoalResponseDTO increaseCurrentValue (UUID goalId, UUID userId) {

--- a/src/main/java/beyou/beyouapp/backend/domain/goal/GoalService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/goal/GoalService.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import beyou.beyouapp.backend.domain.category.Category;
 import beyou.beyouapp.backend.domain.category.CategoryService;
@@ -25,7 +26,6 @@ import beyou.beyouapp.backend.exceptions.goal.GoalNotFound;
 import beyou.beyouapp.backend.exceptions.user.UserNotFound;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -46,6 +46,9 @@ public class GoalService {
                 .orElseThrow(() -> new GoalNotFound("Goal not found"));
     }
 
+    // Transactional so the mapper can walk lazy category relations: OSIV covers
+    // this on the request thread, but agent tools run on a boundedElastic thread.
+    @Transactional(readOnly = true)
     @Cacheable(cacheNames = "goals", key = "#userId")
     public List<GoalResponseDTO> getAllGoals(UUID userId) {
         return goalRepository.findAllByUserId(userId)

--- a/src/main/java/beyou/beyouapp/backend/domain/habit/HabitMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/habit/HabitMapper.java
@@ -62,7 +62,9 @@ public class HabitMapper {
                 habit.getIconId(),
                 habit.getImportance(),
                 habit.getDificulty(),
-                habit.getCategories(),
+                // Copy eagerly while the session is open: the lazy collection must
+                // not leak into the DTO — streaming serializes with no session.
+                habit.getCategories() != null ? new ArrayList<>(habit.getCategories()) : List.of(),
                 xpProgress != null ? xpProgress.getXp() : 0,
                 xpProgress != null ? xpProgress.getActualLevelXp() : 0,
                 xpProgress != null ? xpProgress.getNextLevelXp() : 0,

--- a/src/main/java/beyou/beyouapp/backend/domain/habit/HabitService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/habit/HabitService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import beyou.beyouapp.backend.domain.category.Category;
 import beyou.beyouapp.backend.domain.category.CategoryService;
@@ -26,7 +27,6 @@ import beyou.beyouapp.backend.exceptions.habit.HabitNotFound;
 import beyou.beyouapp.backend.exceptions.user.UserNotFound;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -60,6 +60,9 @@ public class HabitService {
         .orElseThrow(() -> new HabitNotFound("Habit not found"));
     }
 
+    // Transactional so the mapper can walk lazy habitGroups: OSIV covers this
+    // on the request thread, but agent tools run on a boundedElastic thread.
+    @Transactional(readOnly = true)
     @Cacheable(cacheNames = "habits", key = "#userId")
     public List<HabitResponseDTO> getHabits(UUID userId){
         ArrayList<Habit> habits = habitRepository.findAllByUserId(userId);

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/checks/CheckItemService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/checks/CheckItemService.java
@@ -16,6 +16,7 @@ import beyou.beyouapp.backend.domain.common.XpCalculatorService;
 import beyou.beyouapp.backend.domain.common.DTO.RefreshItemCheckedDTO;
 import beyou.beyouapp.backend.domain.common.DTO.RefreshUiDTO;
 import beyou.beyouapp.backend.domain.habit.Habit;
+import beyou.beyouapp.backend.domain.routine.Routine;
 import beyou.beyouapp.backend.domain.routine.itemGroup.HabitGroup;
 import beyou.beyouapp.backend.domain.routine.itemGroup.TaskGroup;
 import beyou.beyouapp.backend.domain.routine.itemGroup.ItemGroupService;
@@ -26,7 +27,6 @@ import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.itemGroup.S
 import beyou.beyouapp.backend.domain.task.Task;
 import beyou.beyouapp.backend.exceptions.BusinessException;
 import beyou.beyouapp.backend.exceptions.ErrorKey;
-import beyou.beyouapp.backend.security.AuthenticatedUser;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +39,6 @@ public class CheckItemService {
 
     private final ItemGroupService itemGroupService;
     private final XpCalculatorService xpCalculatorService;
-    private final AuthenticatedUser authenticatedUser;
     private final UserService userService;
     private final RefreshUiDtoBuilder refreshUiDtoBuilder;
 
@@ -63,7 +62,7 @@ public class CheckItemService {
         if(skipGroupDTO.habitGroupDTO() != null){
             HabitGroup habitGroup = itemGroupService.findHabitGroupByDTO(skipGroupDTO.routineId(), skipGroupDTO.habitGroupDTO().habitGroupId());
             if (isHabitGroupChecked(habitGroup, date)) {
-                return buildNoOpRefresh(habitGroup.getId(), getHabitGroupChecked(habitGroup, date), date);
+                return buildNoOpRefresh(habitGroup.getId(), getHabitGroupChecked(habitGroup, date), date, habitGroup.getRoutineSection().getRoutine());
             }
             return skipGroupDTO.skip()
                 ? skipHabitGroup(habitGroup, date)
@@ -71,7 +70,7 @@ public class CheckItemService {
         }else if(skipGroupDTO.taskGroupDTO() != null){
             TaskGroup taskGroup = itemGroupService.findTaskGroupByDTO(skipGroupDTO.routineId(), skipGroupDTO.taskGroupDTO().taskGroupId());
             if (isTaskGroupChecked(taskGroup, date)) {
-                return buildNoOpRefresh(taskGroup.getId(), getTaskGroupChecked(taskGroup, date), date);
+                return buildNoOpRefresh(taskGroup.getId(), getTaskGroupChecked(taskGroup, date), date, taskGroup.getRoutineSection().getRoutine());
             }
             return skipGroupDTO.skip()
                 ? skipTaskGroup(taskGroup, date)
@@ -144,7 +143,8 @@ public class CheckItemService {
                 date,
                 null,
                 null,
-                new RefreshItemCheckedDTO(habitGroup.getId(), check)
+                new RefreshItemCheckedDTO(habitGroup.getId(), check),
+                routine.getUser()
         );
     }
 
@@ -158,7 +158,8 @@ public class CheckItemService {
                 date,
                 null,
                 null,
-                new RefreshItemCheckedDTO(habitGroup.getId(), check)
+                new RefreshItemCheckedDTO(habitGroup.getId(), check),
+                routine.getUser()
         );
     }
 
@@ -172,7 +173,8 @@ public class CheckItemService {
                 date,
                 null,
                 null,
-                new RefreshItemCheckedDTO(taskGroup.getId(), check)
+                new RefreshItemCheckedDTO(taskGroup.getId(), check),
+                routine.getUser()
         );
     }
 
@@ -186,16 +188,18 @@ public class CheckItemService {
                 date,
                 null,
                 null,
-                new RefreshItemCheckedDTO(taskGroup.getId(), check)
+                new RefreshItemCheckedDTO(taskGroup.getId(), check),
+                routine.getUser()
         );
     }
 
-    private RefreshUiDTO buildNoOpRefresh(UUID groupId, BaseCheck check, LocalDate date) {
+    private RefreshUiDTO buildNoOpRefresh(UUID groupId, BaseCheck check, LocalDate date, Routine routine) {
         return refreshUiDtoBuilder.buildRefreshUiDto(
                 date,
                 null,
                 null,
-                new RefreshItemCheckedDTO(groupId, check)
+                new RefreshItemCheckedDTO(groupId, check),
+                routine.getUser()
         );
     }
 
@@ -272,9 +276,10 @@ public class CheckItemService {
         // Remove xp, decrease level if needed and remove constance
         habitGroupToUncheck.getHabitGroupChecks().remove(existingCheck);
         xpCalculatorService.removeXpOfUserRoutineHabitAndCategoriesAndPersist(
+            routine.getUser(),
             existingCheck.getXpGenerated(),
-            routine, 
-            habitToCheck, 
+            routine,
+            habitToCheck,
             habitToCheck.getCategories()
         );
         habitToCheck.setConstance(habitToCheck.getConstance() - 1);
@@ -292,7 +297,8 @@ public class CheckItemService {
             date, 
             habitToCheck, 
             habitToCheck.getCategories(), 
-            new RefreshItemCheckedDTO(habitGroupToUncheck.getId(), existingCheck)
+            new RefreshItemCheckedDTO(habitGroupToUncheck.getId(), existingCheck),
+            routine.getUser()
         );
     }
 
@@ -321,8 +327,9 @@ public class CheckItemService {
             double newXp = CheckXpCalculator.calculate(dificulty, importance, 0); // tasks have no streak
             check.setXpGenerated(newXp);
             xpCalculatorService.addXpToUserRoutineAndCategoriesAndPersist(
+                routine.getUser(),
                 newXp,
-                routine, 
+                routine,
                 taskChecked.getCategories()
             );
         }
@@ -345,7 +352,8 @@ public class CheckItemService {
                 new RefreshItemCheckedDTO(
                     taskGroupToCheck.getId(),
                     check
-                )
+                ),
+                routine.getUser()
             );
     }
 
@@ -362,9 +370,10 @@ public class CheckItemService {
         double newXp = CheckXpCalculator.calculate(
                 habitChecked.getDificulty(), habitChecked.getImportance(), habitChecked.getConstance());
         xpCalculatorService.addXpToUserRoutineHabitAndCategoriesAndPersist(
-            newXp, 
-            routine, 
-            habitChecked, 
+            routine.getUser(),
+            newXp,
+            routine,
+            habitChecked,
             habitChecked.getCategories()
         );
         habitChecked.setConstance(habitChecked.getConstance() + 1);
@@ -389,7 +398,8 @@ public class CheckItemService {
             new RefreshItemCheckedDTO(
                 habitGroupToCheckOrUncheck.getId(),
                 check
-            )
+            ),
+            routine.getUser()
         );
     }
 
@@ -408,8 +418,9 @@ public class CheckItemService {
         taskGroupUnchecked.getTaskGroupChecks().remove(existingCheck);
         if(taskChecked.getCategories() != null && taskChecked.getCategories().size() > 0){
             xpCalculatorService.removeXpOfUserRoutineAndCategoriesAndPersist(
+                routine.getUser(),
                 existingCheck.getXpGenerated(),
-                routine, 
+                routine,
                 taskChecked.getCategories()
             );
         }
@@ -435,7 +446,8 @@ public class CheckItemService {
             new RefreshItemCheckedDTO(
                 taskGroupUnchecked.getId(),
                 existingCheck
-            )
+            ),
+            routine.getUser()
         );
     }
 
@@ -466,7 +478,9 @@ public class CheckItemService {
     }
 
     private void decreaseUserConstanceIfNeeded(DiaryRoutine routine, LocalDate date) {
-        User user = authenticatedUser.getAuthenticatedUser();
+        // Identity travels with the data (the routine's owner), not a ThreadLocal:
+        // agent tools run on a boundedElastic thread with no SecurityContext.
+        User user = routine.getUser();
         user.setCompletedDays(user.getCompletedDays() == null ? new HashSet<>() : user.getCompletedDays());
 
         log.info("[DEBUG] Checking date => {} in user dates {}", date, user.getCompletedDays());
@@ -492,7 +506,9 @@ public class CheckItemService {
     }
 
     private void increaseUserConstanceIfNeeded(DiaryRoutine routine, LocalDate date) {
-        User user = authenticatedUser.getAuthenticatedUser();
+        // Identity travels with the data (the routine's owner), not a ThreadLocal:
+        // agent tools run on a boundedElastic thread with no SecurityContext.
+        User user = routine.getUser();
 
         user.setCompletedDays(user.getCompletedDays() == null ? new HashSet<>() : user.getCompletedDays());
         if(user.getCompletedDays().contains(date) == true) return ; //Already increased today

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/schedule/ScheduleService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/schedule/ScheduleService.java
@@ -2,6 +2,7 @@ package beyou.beyouapp.backend.domain.routine.schedule;
 
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import beyou.beyouapp.backend.domain.common.UserCacheEvictService;
 import beyou.beyouapp.backend.domain.routine.schedule.dto.CreateScheduleDTO;
@@ -24,6 +25,10 @@ public class ScheduleService {
     private final DiaryRoutineService diaryRoutineService;
     private final UserCacheEvictService userCacheEvictService;
 
+    // Transactional so ScheduleResponseDTO.from can copy the lazy days set:
+    // OSIV covers this on the request thread, but agent tools run on a
+    // boundedElastic thread.
+    @Transactional(readOnly = true)
     @Cacheable(cacheNames = "schedules", key = "#userId")
     public List<ScheduleResponseDTO> findAll(UUID userId) {
         List<DiaryRoutine> routines = diaryRoutineService.getAllDiaryRoutinesModels(userId);

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/schedule/dto/ScheduleResponseDTO.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/schedule/dto/ScheduleResponseDTO.java
@@ -11,6 +11,8 @@ public record ScheduleResponseDTO(
     Set<WeekDay> days
 ) {
     public static ScheduleResponseDTO from(Schedule schedule) {
-        return new ScheduleResponseDTO(schedule.getId(), schedule.getDays());
+        // Copy eagerly while the session is open: the lazy collection must not
+        // leak into the DTO — streaming serializes on a thread with no session.
+        return new ScheduleResponseDTO(schedule.getId(), Set.copyOf(schedule.getDays()));
     }
 }

--- a/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutineMapper.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/routine/specializedRoutines/DiaryRoutineMapper.java
@@ -21,6 +21,7 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -70,7 +71,7 @@ public class DiaryRoutineMapper {
         if (schedule == null) {
             return null;
         }
-        return new DiaryRoutineResponseDTO.ScheduleResponseDTO(schedule.getId(), schedule.getDays());
+        return new DiaryRoutineResponseDTO.ScheduleResponseDTO(schedule.getId(), Set.copyOf(schedule.getDays()));
     }
 
     public List<RoutineSection> mapToRoutineSections(List<RoutineSectionRequestDTO> dtos, DiaryRoutine diaryRoutine) {

--- a/src/main/java/beyou/beyouapp/backend/domain/task/TaskService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/task/TaskService.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import beyou.beyouapp.backend.domain.category.Category;
@@ -28,7 +29,6 @@ import beyou.beyouapp.backend.exceptions.task.TaskNotFound;
 import beyou.beyouapp.backend.exceptions.user.UserNotFound;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,6 +47,9 @@ public class TaskService {
         return taskRepository.findById(taskId).orElseThrow(() -> new TaskNotFound("Task not found"));
     }
 
+    // Transactional so the mapper can walk lazy category relations: OSIV covers
+    // this on the request thread, but agent tools run on a boundedElastic thread.
+    @Transactional(readOnly = true)
     @Cacheable(cacheNames = "tasks", key = "#userId")
     public List<TaskResponseDTO> getAllTasks(UUID userId){
         List<Task> tasks = taskRepository.findAllByUserId(userId).orElseThrow(() -> new UserNotFound("User not found when tried to get tasks"));

--- a/src/main/java/beyou/beyouapp/backend/security/SecurityConfig.java
+++ b/src/main/java/beyou/beyouapp/backend/security/SecurityConfig.java
@@ -16,6 +16,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import jakarta.servlet.DispatcherType;
+
 
 @Configuration
 @EnableWebSecurity
@@ -35,6 +37,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         .requestMatchers(
                             "/auth/login",
                             "/auth/register",

--- a/src/main/java/beyou/beyouapp/backend/security/SecurityConfig.java
+++ b/src/main/java/beyou/beyouapp/backend/security/SecurityConfig.java
@@ -37,6 +37,13 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
+                        // ASYNC dispatch (SseEmitter re-dispatch for streaming) is permitted:
+                        // DispatcherType.ASYNC is set only by the container on re-dispatch, never
+                        // by a client, and SecurityFilter (OncePerRequestFilter) skips async
+                        // dispatch. INVARIANT: every protected endpoint must authenticate + run its
+                        // ownership check on the INITIAL REQUEST dispatch (the agent stream does, via
+                        // getChat(chatId, userId)) — anything relying on auth during async re-dispatch
+                        // would be silently permitted here.
                         .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         .requestMatchers(
                             "/auth/login",

--- a/src/main/java/beyou/beyouapp/backend/security/ratelimit/RateLimitConfig.java
+++ b/src/main/java/beyou/beyouapp/backend/security/ratelimit/RateLimitConfig.java
@@ -59,6 +59,21 @@ public class RateLimitConfig {
                 .build();
     }
 
+    /**
+     * AI agent chat streams: each opens a long-lived SSE emitter, calls the LLM,
+     * and runs a tool loop — expensive, but conversational, so more generous than
+     * one-shot generation. 30/hour per user caps external-billing abuse while
+     * leaving room for a real back-and-forth.
+     */
+    public static Bucket createAgentChatBucket() {
+        return Bucket.builder()
+                .addLimit(Bandwidth.builder()
+                        .capacity(30)
+                        .refillGreedy(30, Duration.ofHours(1))
+                        .build())
+                .build();
+    }
+
     /** Public, unauthenticated GET /user/photo/** — per-IP so anonymous callers can't flood disk reads. */
     public static Bucket createPhotoBucket() {
         return Bucket.builder()

--- a/src/main/java/beyou/beyouapp/backend/security/ratelimit/RateLimitFilter.java
+++ b/src/main/java/beyou/beyouapp/backend/security/ratelimit/RateLimitFilter.java
@@ -33,6 +33,12 @@ public class RateLimitFilter extends OncePerRequestFilter {
     /** AI generation gets its own (much tighter) bucket — see RateLimitConfig.createAiBucket. */
     private static final String AI_GENERATE_PATH = "/ai/routine/generate";
 
+    /** AI agent chat streams get their own bucket, NOT the generic write bucket:
+     *  each stream is an expensive long-lived LLM call. */
+    private static boolean isAgentStreamPath(String path) {
+        return path.startsWith("/ai/agent/chats/") && path.endsWith("/stream");
+    }
+
     @Override
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                   FilterChain filterChain) throws ServletException, IOException {
@@ -61,6 +67,14 @@ public class RateLimitFilter extends OncePerRequestFilter {
             }
             bucketKey = "ai:" + userId;
             bucket = rateLimitCache.get(bucketKey, k -> RateLimitConfig.createAiBucket());
+        } else if (isAgentStreamPath(path)) {
+            String userId = getUserIdFromRequest(request);
+            if (userId == null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+            bucketKey = "agent-stream:" + userId;
+            bucket = rateLimitCache.get(bucketKey, k -> RateLimitConfig.createAgentChatBucket());
         } else if (path.startsWith("/docs") && !path.startsWith("/docs/admin")) {
             String ip = getClientIp(request);
             bucketKey = "docs:" + ip;

--- a/src/main/resources/db/migration/V7__agent_message.sql
+++ b/src/main/resources/db/migration/V7__agent_message.sql
@@ -1,0 +1,25 @@
+-- Display history for agent chats: an ordered, structured transcript per turn.
+-- Distinct from SPRING_AI_CHAT_MEMORY (V4), which is the MODEL's working memory
+-- (window-limited, text-only). This table is what the UI renders: full history,
+-- with the assistant turn stored as ordered segments (text interleaved with the
+-- tools the agent used) in a JSON content string.
+--
+-- Squawk ignores (per line): role is a bounded enum-like string; content is a
+-- JSON blob kept as text (app-side (de)serialization, DB-agnostic); created_at
+-- orders within a turn and is written by the server clock. Cascade delete so
+-- removing a chat cleans its transcript. New table on a pre-production database.
+CREATE TABLE IF NOT EXISTS agent_message (
+    id uuid NOT NULL,
+    chat_id uuid NOT NULL,
+    -- squawk-ignore prefer-text-field
+    role varchar(10) NOT NULL CHECK (role IN ('USER', 'ASSISTANT')),
+    content text NOT NULL,
+    sequence_id bigint NOT NULL,
+    -- squawk-ignore prefer-timestamp-tz
+    created_at timestamp NOT NULL,
+    CONSTRAINT pk_agent_message PRIMARY KEY (id),
+    CONSTRAINT fk_agent_message_chat FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS agent_message_chat_id_sequence_id_idx
+ON agent_message(chat_id, sequence_id);

--- a/src/main/resources/db/migration/V8__agent_message_unique_sequence.sql
+++ b/src/main/resources/db/migration/V8__agent_message_unique_sequence.sql
@@ -6,14 +6,14 @@
 --
 -- The unique index also serves findByChatIdOrderBySequenceIdAsc, so the plain
 -- index from V7 is redundant and dropped. Pre-production table (only exists on
--- this branch) — no backfill/dedupe needed.
---
--- squawk-ignore disallowed-unique-constraint
-ALTER TABLE agent_message
-    DROP CONSTRAINT IF EXISTS uq_agent_message_chat_sequence;
+-- this branch) — no backfill/dedupe needed, and the ACCESS EXCLUSIVE locks these
+-- statements take are instant on an empty/tiny table (same rationale as V2/V7).
+-- Squawk ignores are per-line (attach to the next line).
 
+ALTER TABLE agent_message DROP CONSTRAINT IF EXISTS uq_agent_message_chat_sequence;
+
+-- squawk-ignore require-concurrent-index-deletion
 DROP INDEX IF EXISTS agent_message_chat_id_sequence_id_idx;
 
--- squawk-ignore disallowed-unique-constraint
-ALTER TABLE agent_message
-    ADD CONSTRAINT uq_agent_message_chat_sequence UNIQUE (chat_id, sequence_id);
+-- squawk-ignore constraint-missing-not-valid, disallowed-unique-constraint
+ALTER TABLE agent_message ADD CONSTRAINT uq_agent_message_chat_sequence UNIQUE (chat_id, sequence_id);

--- a/src/main/resources/db/migration/V8__agent_message_unique_sequence.sql
+++ b/src/main/resources/db/migration/V8__agent_message_unique_sequence.sql
@@ -1,0 +1,19 @@
+-- Make (chat_id, sequence_id) unique so a non-atomic sequence assignment can
+-- never silently write duplicate ordinals (which would render the transcript in
+-- a nondeterministic order). The sequence is now assigned under a per-chat
+-- advisory lock (AgentMessageService), so collisions shouldn't happen — this is
+-- defense in depth that fails loudly if one ever slips through.
+--
+-- The unique index also serves findByChatIdOrderBySequenceIdAsc, so the plain
+-- index from V7 is redundant and dropped. Pre-production table (only exists on
+-- this branch) — no backfill/dedupe needed.
+--
+-- squawk-ignore disallowed-unique-constraint
+ALTER TABLE agent_message
+    DROP CONSTRAINT IF EXISTS uq_agent_message_chat_sequence;
+
+DROP INDEX IF EXISTS agent_message_chat_id_sequence_id_idx;
+
+-- squawk-ignore disallowed-unique-constraint
+ALTER TABLE agent_message
+    ADD CONSTRAINT uq_agent_message_chat_sequence UNIQUE (chat_id, sequence_id);

--- a/src/test/java/beyou/beyouapp/backend/controller/AiAgentControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/AiAgentControllerTest.java
@@ -28,7 +28,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import beyou.beyouapp.backend.AbstractIntegrationTest;
 import beyou.beyouapp.backend.domain.aiAgent.AiAgentService;
 import beyou.beyouapp.backend.domain.aiAgent.chat.ChatService;
-import beyou.beyouapp.backend.domain.aiAgent.chat.dto.ChatMessageDTO;
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentMessageDTO;
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentSegment;
 import beyou.beyouapp.backend.domain.aiAgent.chat.dto.ChatResponseDTO;
 import beyou.beyouapp.backend.security.AuthenticatedUser;
 import beyou.beyouapp.backend.user.User;
@@ -129,12 +130,14 @@ public class AiAgentControllerTest extends AbstractIntegrationTest {
     @Test
     void shouldGetMessages() throws Exception {
         when(agentService.getMessages(chatId, userId))
-                .thenReturn(List.of(new ChatMessageDTO("USER", "Hello"), new ChatMessageDTO("ASSISTANT", "Hi!")));
+                .thenReturn(List.of(
+                        new AgentMessageDTO("USER", List.of(AgentSegment.text("Hello"))),
+                        new AgentMessageDTO("ASSISTANT", List.of(AgentSegment.text("Hi!")))));
 
         mockMvc.perform(get("/ai/agent/chats/" + chatId + "/messages"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].role").value("USER"))
-                .andExpect(jsonPath("$[1].text").value("Hi!"));
+                .andExpect(jsonPath("$[1].segments[0].text").value("Hi!"));
     }
 
     @Test

--- a/src/test/java/beyou/beyouapp/backend/domain/aiAgent/AgentTurnBuilderTest.java
+++ b/src/test/java/beyou/beyouapp/backend/domain/aiAgent/AgentTurnBuilderTest.java
@@ -1,0 +1,87 @@
+package beyou.beyouapp.backend.domain.aiAgent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentSegment;
+import beyou.beyouapp.backend.domain.aiAgent.dto.AgentEvent;
+
+/**
+ * The transcript core: turns the ordered event stream into the segments the
+ * done event carries and the DB persists. Same package so the package-private
+ * builder is reachable.
+ */
+class AgentTurnBuilderTest {
+
+    @Test
+    void consecutiveTokensCollapseIntoOneTextSegment() {
+        AgentTurnBuilder turn = new AgentTurnBuilder();
+        turn.observe(AgentEvent.token("Hello"));
+        turn.observe(AgentEvent.token(", "));
+        turn.observe(AgentEvent.token("world"));
+
+        List<AgentSegment> segments = turn.build();
+
+        assertEquals(1, segments.size());
+        assertEquals("text", segments.get(0).type());
+        assertEquals("Hello, world", segments.get(0).text());
+    }
+
+    @Test
+    void onlyFinishedToolsAreRecorded_startedIsLiveOnly() {
+        AgentTurnBuilder turn = new AgentTurnBuilder();
+        turn.observe(AgentEvent.toolStarted("createUserHabit"));
+        turn.observe(AgentEvent.toolFinished("createUserHabit", null, List.of("habits")));
+
+        List<AgentSegment> segments = turn.build();
+
+        assertEquals(1, segments.size());
+        AgentSegment tool = segments.get(0);
+        assertEquals("tool", tool.type());
+        assertEquals("createUserHabit", tool.tool());
+        assertNull(tool.error());
+        assertEquals(List.of("habits"), tool.domains());
+    }
+
+    @Test
+    void textAndToolsInterleaveInCausalOrder() {
+        AgentTurnBuilder turn = new AgentTurnBuilder();
+        turn.observe(AgentEvent.token("Let me check. "));
+        turn.observe(AgentEvent.toolStarted("getUserCategories"));
+        turn.observe(AgentEvent.toolFinished("getUserCategories", null, List.of()));
+        turn.observe(AgentEvent.token("Done."));
+
+        List<AgentSegment> segments = turn.build();
+
+        assertEquals(3, segments.size());
+        assertEquals("text", segments.get(0).type());
+        assertEquals("Let me check. ", segments.get(0).text());
+        assertEquals("tool", segments.get(1).type());
+        assertEquals("getUserCategories", segments.get(1).tool());
+        assertEquals("text", segments.get(2).type());
+        assertEquals("Done.", segments.get(2).text());
+    }
+
+    @Test
+    void failedToolCarriesItsError() {
+        AgentTurnBuilder turn = new AgentTurnBuilder();
+        turn.observe(AgentEvent.toolFinished("deleteUserHabit", "HabitInRoutineException", List.of("habits")));
+
+        AgentSegment tool = turn.build().get(0);
+        assertEquals("HabitInRoutineException", tool.error());
+    }
+
+    @Test
+    void doneAndErrorEventsAreNotPartOfTheTranscript() {
+        AgentTurnBuilder turn = new AgentTurnBuilder();
+        turn.observe(AgentEvent.done(List.of(AgentSegment.text("ignored"))));
+        turn.observe(AgentEvent.error("SOME_KEY"));
+
+        assertTrue(turn.build().isEmpty());
+    }
+}

--- a/src/test/java/beyou/beyouapp/backend/integration/aiAgent/AgentMessageServiceIntegrationTest.java
+++ b/src/test/java/beyou/beyouapp/backend/integration/aiAgent/AgentMessageServiceIntegrationTest.java
@@ -1,0 +1,120 @@
+package beyou.beyouapp.backend.integration.aiAgent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import beyou.beyouapp.backend.AbstractIntegrationTest;
+import beyou.beyouapp.backend.domain.aiAgent.chat.Chat;
+import beyou.beyouapp.backend.domain.aiAgent.chat.ChatRepository;
+import beyou.beyouapp.backend.domain.aiAgent.chat.AgentMessageRepository;
+import beyou.beyouapp.backend.domain.aiAgent.chat.AgentMessageService;
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentMessageDTO;
+import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentSegment;
+import beyou.beyouapp.backend.user.User;
+import beyou.beyouapp.backend.user.UserRepository;
+
+/** Persistence + ordering for the display transcript, including the concurrent
+ *  sequence-assignment race (#2) against a real Postgres. */
+class AgentMessageServiceIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired private AgentMessageService agentMessageService;
+    @Autowired private AgentMessageRepository agentMessageRepository;
+    @Autowired private ChatRepository chatRepository;
+    @Autowired private UserRepository userRepository;
+
+    // Track only what this class creates so teardown can be FK-safe and scoped —
+    // the Postgres container is shared, so a broad deleteAll would wipe siblings.
+    private final List<UUID> createdChatIds = new ArrayList<>();
+    private final List<UUID> createdUserIds = new ArrayList<>();
+
+    private Chat newChat() {
+        User user = new User();
+        user.setName("Agent Msg IT");
+        user.setEmail("agent-msg-" + UUID.randomUUID() + "@test.com");
+        user.setPassword("password123");
+        user = userRepository.saveAndFlush(user);
+
+        Chat chat = new Chat();
+        chat.setUser(user);
+        chat.setTitle("IT chat");
+        chat = chatRepository.saveAndFlush(chat);
+
+        createdUserIds.add(user.getId());
+        createdChatIds.add(chat.getId());
+        return chat;
+    }
+
+    @AfterEach
+    void cleanUp() {
+        createdChatIds.forEach(chatRepository::deleteById); // cascades agent_message (V7 FK)
+        createdUserIds.forEach(userRepository::deleteById);
+        createdChatIds.clear();
+        createdUserIds.clear();
+    }
+
+    @Test
+    void recordTurnStoresUserThenAssistantAsOrderedSegments() {
+        UUID chatId = newChat().getId();
+
+        agentMessageService.recordTurn(chatId, "create a habit",
+                List.of(AgentSegment.text("Done! "), AgentSegment.tool("createUserHabit", null, List.of("habits"))));
+
+        List<AgentMessageDTO> messages = agentMessageService.getMessages(chatId);
+        assertEquals(2, messages.size());
+        assertEquals("USER", messages.get(0).role());
+        assertEquals("create a habit", messages.get(0).segments().get(0).text());
+        assertEquals("ASSISTANT", messages.get(1).role());
+        assertEquals("tool", messages.get(1).segments().get(1).type());
+        assertEquals("createUserHabit", messages.get(1).segments().get(1).tool());
+    }
+
+    @Test
+    void concurrentTurnsGetDistinctContiguousSequenceIds() throws Exception {
+        UUID chatId = newChat().getId();
+        int turns = 12;
+
+        ExecutorService pool = Executors.newFixedThreadPool(turns);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(turns);
+
+        for (int i = 0; i < turns; i++) {
+            final int n = i;
+            pool.submit(() -> {
+                try {
+                    start.await(); // fire them as simultaneously as possible
+                    agentMessageService.recordTurn(chatId, "msg " + n,
+                            List.of(AgentSegment.text("reply " + n)));
+                } catch (Exception ignored) {
+                    // a failure would show up as a missing/duplicate seq below
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        start.countDown();
+        assertTrue(done.await(30, TimeUnit.SECONDS), "turns did not finish in time");
+        pool.shutdownNow();
+
+        List<Long> seqs = agentMessageRepository.findByChatIdOrderBySequenceIdAsc(chatId)
+                .stream().map(m -> m.getSequenceId()).collect(Collectors.toList());
+
+        // 12 turns * 2 rows each, sequence ids exactly 0..23 with no gaps/dupes
+        // (the per-chat advisory lock + unique constraint guarantee this).
+        assertEquals(turns * 2, seqs.size());
+        assertEquals(IntStream.range(0, turns * 2).mapToObj(Long::valueOf).collect(Collectors.toList()), seqs);
+    }
+}

--- a/src/test/java/beyou/beyouapp/backend/integration/aiAgent/AgentStreamSecurityIntegrationTest.java
+++ b/src/test/java/beyou/beyouapp/backend/integration/aiAgent/AgentStreamSecurityIntegrationTest.java
@@ -1,0 +1,112 @@
+package beyou.beyouapp.backend.integration.aiAgent;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import beyou.beyouapp.backend.AbstractIntegrationTest;
+import beyou.beyouapp.backend.domain.aiAgent.chat.Chat;
+import beyou.beyouapp.backend.domain.aiAgent.chat.ChatRepository;
+import beyou.beyouapp.backend.security.SecurityConfig;
+import beyou.beyouapp.backend.security.RefreshToken.RefreshTokenRepository;
+import beyou.beyouapp.backend.user.User;
+import beyou.beyouapp.backend.user.UserRepository;
+import beyou.beyouapp.backend.user.UserService;
+import beyou.beyouapp.backend.user.dto.UserRegisterDTO;
+
+/**
+ * The streaming endpoint must sit behind auth AND enforce chat ownership on the
+ * initial request dispatch — before any emitter opens or the LLM is called.
+ * Full security filters ON (unlike AiAgentControllerTest which disables them).
+ */
+@AutoConfigureMockMvc
+@Import({ SecurityConfig.class })
+class AgentStreamSecurityIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired UserService userService;
+    @Autowired UserRepository userRepository;
+    @Autowired ChatRepository chatRepository;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+
+    private static final String PASSWORD = "TestPassword1!";
+    private UUID ownerChatId;
+    private String otherUserToken;
+    // Track only what this class creates for a scoped, FK-safe teardown — the
+    // Postgres container is shared, so a broad deleteAll would wipe siblings
+    // (and leftover chats/tokens would break another class's user deleteAll).
+    private final List<UUID> createdUserIds = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User owner = registerAndVerify("owner-" + UUID.randomUUID() + "@test.com");
+        Chat chat = new Chat();
+        chat.setUser(owner);
+        chat.setTitle("owner's chat");
+        ownerChatId = chatRepository.saveAndFlush(chat).getId();
+
+        String otherEmail = "other-" + UUID.randomUUID() + "@test.com";
+        registerAndVerify(otherEmail);
+        otherUserToken = login(otherEmail);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        chatRepository.deleteById(ownerChatId);
+        createdUserIds.forEach(id ->
+                refreshTokenRepository.deleteAll(refreshTokenRepository.findAllByUserId(id)));
+        createdUserIds.forEach(userRepository::deleteById);
+        createdUserIds.clear();
+    }
+
+    @Test
+    void rejectsUnauthenticatedStream() throws Exception {
+        mockMvc.perform(post("/ai/agent/chats/" + ownerChatId + "/stream")
+                        .content("{\"userInput\":\"hello\"}")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorKey").value("JWT_NOT_FOUND"));
+    }
+
+    @Test
+    void rejectsStreamingIntoAnotherUsersChat() throws Exception {
+        // getChat's ownership check runs first, so this fails before any emitter
+        // opens or DeepSeek is called — no API key needed for this path.
+        mockMvc.perform(post("/ai/agent/chats/" + ownerChatId + "/stream")
+                        .header("authorization", "Bearer " + otherUserToken)
+                        .content("{\"userInput\":\"hello\"}")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorKey").value("CHAT_NOT_OWNED"));
+    }
+
+    private User registerAndVerify(String email) {
+        userService.registerUser(new UserRegisterDTO("test", email, PASSWORD));
+        User user = userRepository.findByEmail(email).orElseThrow();
+        user.setEmailVerified(true);
+        user = userRepository.saveAndFlush(user);
+        createdUserIds.add(user.getId());
+        return user;
+    }
+
+    private String login(String email) throws Exception {
+        return mockMvc.perform(post("/auth/login")
+                        .content("{\"email\": \"" + email + "\", \"password\": \"" + PASSWORD + "\"}")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getHeader("X-Access-Token");
+    }
+}

--- a/src/test/java/beyou/beyouapp/backend/unit/common/XpCalculatorServiceTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/common/XpCalculatorServiceTest.java
@@ -25,7 +25,6 @@ import beyou.beyouapp.backend.domain.habit.Habit;
 import beyou.beyouapp.backend.domain.habit.HabitRepository;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutine;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.DiaryRoutineRepository;
-import beyou.beyouapp.backend.security.AuthenticatedUser;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserRepository;
 
@@ -34,9 +33,6 @@ class XpCalculatorServiceTest {
 
     @Mock
     private XpByLevelRepository xpByLevelRepository;
-
-    @Mock
-    private AuthenticatedUser authenticatedUser;
 
     @Mock
     private UserRepository userRepository;
@@ -76,13 +72,11 @@ class XpCalculatorServiceTest {
         category.setId(UUID.randomUUID());
         seedXp(category.getXpProgress(), 0);
         categories = new ArrayList<>(List.of(category));
-
-        when(authenticatedUser.getAuthenticatedUser()).thenReturn(user);
     }
 
     @Test
     void shouldAddXpToUserRoutineHabitAndCategories() {
-        xpCalculatorService.addXpToUserRoutineHabitAndCategoriesAndPersist(50.0, routine, habit, categories);
+        xpCalculatorService.addXpToUserRoutineHabitAndCategoriesAndPersist(user, 50.0, routine, habit, categories);
 
         assertEquals(50.0, user.getXpProgress().getXp());
         assertEquals(50.0, routine.getXpProgress().getXp());
@@ -99,7 +93,7 @@ class XpCalculatorServiceTest {
     void shouldAddXpToUserRoutineAndCategoriesWithoutHabit() {
         seedXp(habit.getXpProgress(), 100.0);
 
-        xpCalculatorService.addXpToUserRoutineAndCategoriesAndPersist(30.0, routine, categories);
+        xpCalculatorService.addXpToUserRoutineAndCategoriesAndPersist(user, 30.0, routine, categories);
 
         assertEquals(30.0, user.getXpProgress().getXp());
         assertEquals(30.0, routine.getXpProgress().getXp());
@@ -119,7 +113,7 @@ class XpCalculatorServiceTest {
         seedXp(habit.getXpProgress(), 80.0);
         seedXp(categories.get(0).getXpProgress(), 80.0);
 
-        xpCalculatorService.removeXpOfUserRoutineHabitAndCategoriesAndPersist(30.0, routine, habit, categories);
+        xpCalculatorService.removeXpOfUserRoutineHabitAndCategoriesAndPersist(user, 30.0, routine, habit, categories);
 
         assertEquals(50.0, user.getXpProgress().getXp());
         assertEquals(50.0, routine.getXpProgress().getXp());
@@ -137,7 +131,7 @@ class XpCalculatorServiceTest {
         seedXp(user.getXpProgress(), 60.0);
         seedXp(routine.getXpProgress(), 60.0);
 
-        xpCalculatorService.removeXpOfUserRoutineAndCategoriesAndPersist(10.0, routine, new ArrayList<>());
+        xpCalculatorService.removeXpOfUserRoutineAndCategoriesAndPersist(user, 10.0, routine, new ArrayList<>());
 
         assertEquals(50.0, user.getXpProgress().getXp());
         assertEquals(50.0, routine.getXpProgress().getXp());

--- a/src/test/java/beyou/beyouapp/backend/unit/goal/goalServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/goal/goalServiceUnitTest.java
@@ -292,7 +292,7 @@ public class goalServiceUnitTest {
         when(goalRepository.findById(goalId)).thenReturn(Optional.of(goal));
         double xp = GoalXpCalculator.calculateXp(goal);
 
-        when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any()))
+        when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any(), any()))
         .thenAnswer(invocation -> new RefreshUiDTO(null, invocation.getArgument(1), null, null));
 
         RefreshUiDTO response = goalService.checkGoal(goalId, userId);
@@ -300,7 +300,7 @@ public class goalServiceUnitTest {
         assertNotNull(response);
         assertEquals(GoalStatus.COMPLETED, goal.getStatus());
         assertEquals(LocalDate.now(), goal.getCompleteDate());
-        verify(xpCalculatorService, times(1)).addXpToUserGoalAndCategoriesAndPersist(xp, goal, goal.getCategories());
+        verify(xpCalculatorService, times(1)).addXpToUserGoalAndCategoriesAndPersist(goal.getUser(), xp, goal, goal.getCategories());
     }
 
     @Test
@@ -309,7 +309,7 @@ public class goalServiceUnitTest {
         double xp = GoalXpCalculator.calculateXp(goal);
 
         when(goalRepository.findById(goalId)).thenReturn(Optional.of(goal));
-        when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any()))
+        when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any(), any()))
         .thenAnswer(invocation -> new RefreshUiDTO(null, invocation.getArgument(1), null, null));
 
         RefreshUiDTO response = goalService.checkGoal(goalId, userId);
@@ -318,7 +318,7 @@ public class goalServiceUnitTest {
         assertEquals(false, goal.getComplete());
         assertEquals(GoalStatus.IN_PROGRESS, goal.getStatus());
         assertEquals(null, goal.getCompleteDate());
-        verify(xpCalculatorService, times(1)).removeXpOfUserGoalAndCategoriesAndPersist(xp, goal, goal.getCategories());
+        verify(xpCalculatorService, times(1)).removeXpOfUserGoalAndCategoriesAndPersist(goal.getUser(), xp, goal, goal.getCategories());
     }
 
     @Test

--- a/src/test/java/beyou/beyouapp/backend/unit/routine/CheckItemServiceSkipUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/routine/CheckItemServiceSkipUnitTest.java
@@ -37,7 +37,6 @@ import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.itemGroup.H
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.itemGroup.SkipGroupRequestDTO;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.itemGroup.TaskGroupRequestDTO;
 import beyou.beyouapp.backend.domain.task.Task;
-import beyou.beyouapp.backend.security.AuthenticatedUser;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserService;
 import beyou.beyouapp.backend.user.enums.ConstanceConfiguration;
@@ -52,9 +51,6 @@ class CheckItemServiceSkipUnitTest {
     private XpCalculatorService xpCalculatorService;
 
     @Mock
-    private AuthenticatedUser authenticatedUser;
-
-    @Mock
     private UserService userService;
 
     @Mock
@@ -67,11 +63,10 @@ class CheckItemServiceSkipUnitTest {
         checkItemService = new CheckItemService(
                 itemGroupService,
                 xpCalculatorService,
-                authenticatedUser,
                 userService,
                 refreshUiDtoBuilder
         );
-        when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any()))
+        when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any(), any()))
                 .thenReturn(new RefreshUiDTO(null, null, null, null));
     }
 
@@ -85,7 +80,7 @@ class CheckItemServiceSkipUnitTest {
         when(itemGroupService.findHabitGroupByDTO(routineId, habitGroupId)).thenReturn(habitGroup);
 
         User user = buildUser(ConstanceConfiguration.COMPLETE);
-        when(authenticatedUser.getAuthenticatedUser()).thenReturn(user);
+        habitGroup.getRoutineSection().getRoutine().setUser(user);
 
         SkipGroupRequestDTO dto = new SkipGroupRequestDTO(
                 routineId,
@@ -114,7 +109,7 @@ class CheckItemServiceSkipUnitTest {
         when(itemGroupService.findHabitGroupByDTO(routineId, habitGroupId)).thenReturn(habitGroup);
 
         User user = buildUser(ConstanceConfiguration.ANY);
-        when(authenticatedUser.getAuthenticatedUser()).thenReturn(user);
+        habitGroup.getRoutineSection().getRoutine().setUser(user);
 
         SkipGroupRequestDTO dto = new SkipGroupRequestDTO(
                 routineId,

--- a/src/test/java/beyou/beyouapp/backend/unit/routine/checks/CheckItemServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/routine/checks/CheckItemServiceUnitTest.java
@@ -44,7 +44,6 @@ import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.itemGroup.C
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.itemGroup.HabitGroupRequestDTO;
 import beyou.beyouapp.backend.domain.routine.specializedRoutines.dto.itemGroup.TaskGroupRequestDTO;
 import beyou.beyouapp.backend.domain.task.Task;
-import beyou.beyouapp.backend.security.AuthenticatedUser;
 import beyou.beyouapp.backend.user.User;
 import beyou.beyouapp.backend.user.UserService;
 import beyou.beyouapp.backend.user.enums.ConstanceConfiguration;
@@ -57,9 +56,6 @@ class CheckItemServiceUnitTest {
 
     @Mock
     private XpCalculatorService xpCalculatorService;
-
-    @Mock
-    AuthenticatedUser authenticatedUser;
 
     @Mock
     UserService userService;
@@ -86,8 +82,7 @@ class CheckItemServiceUnitTest {
             user.setXpProgress(xpProgress);
             user.setMaxConstance(2);
 
-            when(authenticatedUser.getAuthenticatedUser()).thenReturn(user);
-            when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any()))
+            when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any(), any()))
             .thenAnswer(invocation -> new RefreshUiDTO(null, null, null, invocation.getArgument(3)));
         }
         
@@ -118,7 +113,7 @@ class CheckItemServiceUnitTest {
                     habit.getDificulty(), habit.getImportance(), 0); // constance 0 before this check
             assertEquals(expectedXp, check.getXpGenerated());
             assertEquals(1, habit.getConstance());
-            verify(xpCalculatorService).addXpToUserRoutineHabitAndCategoriesAndPersist(expectedXp, routine, habit, habit.getCategories());
+            verify(xpCalculatorService).addXpToUserRoutineHabitAndCategoriesAndPersist(user, expectedXp, routine, habit, habit.getCategories());
         }
 
         @Test
@@ -152,7 +147,7 @@ class CheckItemServiceUnitTest {
             assertFalse(check.isChecked());
             assertEquals(0, check.getXpGenerated());
             assertEquals(1, habit.getConstance());
-            verify(xpCalculatorService).removeXpOfUserRoutineHabitAndCategoriesAndPersist(xpGenerated, routine, habit, habit.getCategories());
+            verify(xpCalculatorService).removeXpOfUserRoutineHabitAndCategoriesAndPersist(user, xpGenerated, routine, habit, habit.getCategories());
         }
 
         @Test
@@ -183,7 +178,7 @@ class CheckItemServiceUnitTest {
                     task.getDificulty(), task.getImportance(), 0); // tasks have no streak
             assertEquals(expectedXp, check.getXpGenerated());
             assertEquals(today, task.getMarkedToDelete());
-            verify(xpCalculatorService).addXpToUserRoutineAndCategoriesAndPersist(expectedXp, routine, task.getCategories());
+            verify(xpCalculatorService).addXpToUserRoutineAndCategoriesAndPersist(user, expectedXp, routine, task.getCategories());
         }
 
         @Test
@@ -217,7 +212,7 @@ class CheckItemServiceUnitTest {
             assertFalse(check.isChecked());
             assertEquals(0, check.getXpGenerated());
             assertNull(task.getMarkedToDelete());
-            verify(xpCalculatorService).removeXpOfUserRoutineAndCategoriesAndPersist(xpGenerated, routine, task.getCategories());
+            verify(xpCalculatorService).removeXpOfUserRoutineAndCategoriesAndPersist(user, xpGenerated, routine, task.getCategories());
         }
     }
 
@@ -235,8 +230,7 @@ class CheckItemServiceUnitTest {
             user.setXpProgress(xpProgress);
             user.setMaxConstance(2);
 
-            when(authenticatedUser.getAuthenticatedUser()).thenReturn(user);
-            when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any()))
+            when(refreshUiDtoBuilder.buildRefreshUiDto(any(), any(), any(), any(), any()))
             .thenAnswer(invocation -> new RefreshUiDTO(null, null, null, invocation.getArgument(3)));        }
 
         @Test
@@ -343,6 +337,7 @@ class CheckItemServiceUnitTest {
         section.setTaskGroups(new ArrayList<>());
         DiaryRoutine routine = new DiaryRoutine();
         routine.setId(UUID.randomUUID());
+        routine.setUser(user);
         routine.setRoutineSections(new ArrayList<>(List.of(section)));
         section.setRoutine(routine);
         habitGroup.setRoutineSection(section);
@@ -370,6 +365,7 @@ class CheckItemServiceUnitTest {
         section.setHabitGroups(new ArrayList<>());
         DiaryRoutine routine = new DiaryRoutine();
         routine.setId(UUID.randomUUID());
+        routine.setUser(user);
         routine.setRoutineSections(new ArrayList<>(List.of(section)));
         section.setRoutine(routine);
         taskGroup.setRoutineSection(section);


### PR DESCRIPTION
Phase 4 of the AI agent: streams the agent's reply token-by-token over SSE, surfaces the tools it uses as live events, and persists a structured transcript. Also fixes a class of \"User not authenticated\" failures that surfaced once tools started running off the request thread.

## Streaming
- **`AgentEvent`** protocol (`token` / `tool` / `done` / `error`) + **`AgentToolDomains`** (each write tool → the frontend Redux slices it touched, so the client can refetch precisely).
- **`MeteredToolCallback`** emits `toolStarted`/`toolFinished` through a per-request `Consumer<AgentEvent>` placed in the `ToolContext` — the channel travels with the data, never a ThreadLocal.
- **`streamMessage`** + `SseEmitter`: subscribes to the DeepSeek token `Flux`, bridges tokens/tool-events to the client; `done` carries the authoritative structured turn; client disconnect cancels the pipeline (and the upstream LLM call).
- **Heartbeat**: a `:ping` comment every 15s keeps idle connections alive through proxies and doubles as dead-client detection during quiet pauses. A per-request lock serializes the heartbeat thread against the reactor thread. Controller sets `X-Accel-Buffering: no` + `Cache-Control: no-cache`.

## Persisted transcript
- New **`agent_message`** table (`V7`) stores each turn as ordered text/tool **segments** (`AgentTurnBuilder` observes the event funnel in causal order).
- `getMessages` reads it, with a fallback to Spring AI memory for chats created before the table. Model memory (Spring AI) stays untouched — it's the model's working memory; this is the display history.

## Identity no longer rides a ThreadLocal
Agent tools run on a reactor `boundedElastic` thread with no `SecurityContext`, so `XpCalculatorService` / `CheckItemService` / `RefreshUiDtoBuilder` pulling the user from `SecurityContextHolder` threw \"User not authenticated\" on check-in and goal completion. Identity now flows from the data (`routine.getUser()` / `goal.getUser()`); the no-user XP overloads and the `authenticatedUser` dependency in those services were removed. Also fixed lazy-collection leaks (`Set.copyOf`/`new ArrayList<>`) that only surfaced when serialization happened off the request thread.

## Tests
Full suite green (473). New/updated coverage: `AiAgentControllerTest` (currentPage + segment messages), XP/check-in/goal tests migrated to the User-explicit overloads.