### PR TITLE
feat(agent): rename chat + reset agent

### DIFF
--- a/src/main/java/beyou/beyouapp/backend/controllers/AiAgentController.java
+++ b/src/main/java/beyou/beyouapp/backend/controllers/AiAgentController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +21,7 @@ import beyou.beyouapp.backend.domain.aiAgent.chat.ChatService;
 import beyou.beyouapp.backend.domain.aiAgent.chat.dto.AgentMessageDTO;
 import beyou.beyouapp.backend.domain.aiAgent.chat.dto.ChatResponseDTO;
 import beyou.beyouapp.backend.domain.aiAgent.dto.CreateChatRequest;
+import beyou.beyouapp.backend.domain.aiAgent.dto.RenameChatRequest;
 import beyou.beyouapp.backend.domain.aiAgent.dto.AiAgentRequest;
 import beyou.beyouapp.backend.security.AuthenticatedUser;
 import jakarta.servlet.http.HttpServletResponse;
@@ -74,11 +76,25 @@ public class AiAgentController {
         return agentService.getMessages(chatId, userId);
     }
 
+    @PutMapping("/chats/{chatId}")
+    public ChatResponseDTO renameChat(@PathVariable UUID chatId, @RequestBody @Valid RenameChatRequest request) {
+        UUID userId = authenticatedUser.getAuthenticatedUser().getId();
+        return chatService.renameChat(chatId, userId, request.title());
+    }
+
     @DeleteMapping("/chats/{chatId}")
     public ResponseEntity<Map<String, String>> deleteChat(@PathVariable UUID chatId) {
         UUID userId = authenticatedUser.getAuthenticatedUser().getId();
         chatService.deleteChat(chatId, userId);
         return ResponseEntity.ok(Map.of("success", "Chat deleted successfully"));
+    }
+
+    /** Reset the agent: delete all chats and clear its remembered context. */
+    @DeleteMapping("/chats")
+    public ResponseEntity<Map<String, String>> deleteAllChats() {
+        UUID userId = authenticatedUser.getAuthenticatedUser().getId();
+        chatService.deleteAllChats(userId);
+        return ResponseEntity.ok(Map.of("success", "All chats deleted successfully"));
     }
 
 }

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/ChatService.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/chat/ChatService.java
@@ -24,6 +24,7 @@ public class ChatService {
     private static final String DEFAULT_TITLE = "New chat";
     public static final int GLOBAL_CONTEXT_MAX = 2000;
     public static final int CHAT_CONTEXT_MAX = 1000;
+    public static final int TITLE_MAX = 255; // matches the chats.title column (V5)
 
     private final ChatRepository chatRepository;
     private final UserRepository userRepository;
@@ -96,6 +97,35 @@ public class ChatService {
         } catch (Exception e) {
             log.error("Error trying to delete chat {}", chatId, e);
             throw new BusinessException(ErrorKey.CHAT_DELETE_FAILED, "Error trying to delete chat");
+        }
+    }
+
+    /** Rename a chat (ownership-checked). Title is trimmed and capped to the column width. */
+    public ChatResponseDTO renameChat(UUID chatId, UUID userId, String title) {
+        Chat chat = getChat(chatId, userId);
+        chat.setTitle(clamp(title, TITLE_MAX));
+        return ChatResponseDTO.from(chatRepository.save(chat));
+    }
+
+    /**
+     * "Reset the agent": delete ALL of the user's chats (cascades messages via
+     * the agent_message FK) and clear the model's memory of them — both the
+     * Spring AI window per chat and the cross-chat global context on the user.
+     */
+    @Transactional
+    public void deleteAllChats(UUID userId) {
+        List<Chat> chats = chatRepository.findAllByUserIdOrderByUpdatedAtDesc(userId);
+        try {
+            chats.forEach(chat -> chatMemory.clear(chat.getId().toString()));
+            chatRepository.deleteAll(chats);
+
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new UserNotFound("User not found when resetting the agent"));
+            user.setUserContext(null);
+            userRepository.save(user);
+        } catch (Exception e) {
+            log.error("Error resetting agent for user {}", userId, e);
+            throw new BusinessException(ErrorKey.CHAT_DELETE_FAILED, "Error trying to reset the agent");
         }
     }
 }

--- a/src/main/java/beyou/beyouapp/backend/domain/aiAgent/dto/RenameChatRequest.java
+++ b/src/main/java/beyou/beyouapp/backend/domain/aiAgent/dto/RenameChatRequest.java
@@ -1,0 +1,7 @@
+package beyou.beyouapp.backend.domain.aiAgent.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RenameChatRequest(@NotBlank @Size(max = 255) String title) {
+}

--- a/src/test/java/beyou/beyouapp/backend/controller/AiAgentControllerTest.java
+++ b/src/test/java/beyou/beyouapp/backend/controller/AiAgentControllerTest.java
@@ -1,11 +1,14 @@
 package beyou.beyouapp.backend.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -147,6 +150,39 @@ public class AiAgentControllerTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.success").value("Chat deleted successfully"));
 
         verify(chatService).deleteChat(chatId, userId);
+    }
+
+    @Test
+    void shouldRenameChat() throws Exception {
+        when(chatService.renameChat(chatId, userId, "Weekly planning"))
+                .thenReturn(new ChatResponseDTO(chatId, "Weekly planning", LocalDateTime.now(), LocalDateTime.now()));
+
+        mockMvc.perform(put("/ai/agent/chats/" + chatId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\": \"Weekly planning\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Weekly planning"));
+
+        verify(chatService).renameChat(chatId, userId, "Weekly planning");
+    }
+
+    @Test
+    void shouldRejectBlankRenameTitle() throws Exception {
+        mockMvc.perform(put("/ai/agent/chats/" + chatId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\": \"   \"}"))
+                .andExpect(status().isBadRequest());
+
+        verify(chatService, never()).renameChat(any(), any(), any());
+    }
+
+    @Test
+    void shouldDeleteAllChats() throws Exception {
+        mockMvc.perform(delete("/ai/agent/chats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value("All chats deleted successfully"));
+
+        verify(chatService).deleteAllChats(userId);
     }
 
 }

--- a/src/test/java/beyou/beyouapp/backend/integration/aiAgent/ChatServiceIntegrationTest.java
+++ b/src/test/java/beyou/beyouapp/backend/integration/aiAgent/ChatServiceIntegrationTest.java
@@ -1,0 +1,81 @@
+package beyou.beyouapp.backend.integration.aiAgent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import beyou.beyouapp.backend.AbstractIntegrationTest;
+import beyou.beyouapp.backend.domain.aiAgent.chat.Chat;
+import beyou.beyouapp.backend.domain.aiAgent.chat.ChatRepository;
+import beyou.beyouapp.backend.domain.aiAgent.chat.ChatService;
+import beyou.beyouapp.backend.user.User;
+import beyou.beyouapp.backend.user.UserRepository;
+
+/**
+ * Proves "reset the agent" is scoped to the caller — deleteAllChats takes the
+ * authenticated user's id (never a request param), so one user resetting can't
+ * touch another's chats or remembered context (no IDOR).
+ */
+class ChatServiceIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired private ChatService chatService;
+    @Autowired private ChatRepository chatRepository;
+    @Autowired private UserRepository userRepository;
+
+    private final List<UUID> userIds = new ArrayList<>();
+
+    private User newUser(String context) {
+        User user = new User();
+        user.setName("Reset IT");
+        user.setEmail("reset-it-" + UUID.randomUUID() + "@test.com");
+        user.setPassword("password123");
+        user.setUserContext(context);
+        user = userRepository.saveAndFlush(user);
+        userIds.add(user.getId());
+        return user;
+    }
+
+    private void newChat(User user) {
+        Chat chat = new Chat();
+        chat.setUser(user);
+        chat.setTitle("chat");
+        chatRepository.saveAndFlush(chat);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        userIds.forEach(id ->
+                chatRepository.deleteAll(chatRepository.findAllByUserIdOrderByUpdatedAtDesc(id)));
+        userIds.forEach(userRepository::deleteById);
+        userIds.clear();
+    }
+
+    @Test
+    void deleteAllChatsOnlyTouchesTheCallersOwnData() {
+        User attacker = newUser("attacker memory");
+        User victim = newUser("victim memory");
+        newChat(attacker);
+        newChat(attacker);
+        newChat(victim);
+        newChat(victim);
+
+        chatService.deleteAllChats(attacker.getId());
+
+        // Attacker's own chats + context are gone...
+        assertTrue(chatRepository.findAllByUserIdOrderByUpdatedAtDesc(attacker.getId()).isEmpty());
+        assertNull(userRepository.findById(attacker.getId()).orElseThrow().getUserContext());
+
+        // ...the victim's are untouched.
+        assertEquals(2, chatRepository.findAllByUserIdOrderByUpdatedAtDesc(victim.getId()).size());
+        assertEquals("victim memory",
+                userRepository.findById(victim.getId()).orElseThrow().getUserContext());
+    }
+}

--- a/src/test/java/beyou/beyouapp/backend/unit/aiAgent/ChatServiceUnitTest.java
+++ b/src/test/java/beyou/beyouapp/backend/unit/aiAgent/ChatServiceUnitTest.java
@@ -2,6 +2,7 @@ package beyou.beyouapp.backend.unit.aiAgent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -208,6 +209,57 @@ public class ChatServiceUnitTest {
 
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> chatService.deleteChat(chatId, userId));
+
+        assertEquals(ErrorKey.CHAT_DELETE_FAILED, exception.getErrorKey());
+    }
+
+    @Test
+    void shouldRenameChatWithTrimmedTitle() {
+        when(chatRepository.findById(chatId)).thenReturn(Optional.of(chat));
+        when(chatRepository.save(any(Chat.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ChatResponseDTO renamed = chatService.renameChat(chatId, userId, "  Weekly planning  ");
+
+        assertEquals("Weekly planning", renamed.title());
+        verify(chatRepository).save(chat);
+    }
+
+    @Test
+    void shouldNotRenameChatOfAnotherUser() {
+        when(chatRepository.findById(chatId)).thenReturn(Optional.of(chat));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> chatService.renameChat(chatId, UUID.randomUUID(), "Hacked"));
+
+        assertEquals(ErrorKey.CHAT_NOT_OWNED, exception.getErrorKey());
+        verify(chatRepository, never()).save(any(Chat.class));
+    }
+
+    @Test
+    void shouldDeleteAllChatsClearMemoryAndWipeGlobalContext() {
+        user.setUserContext("remembered stuff");
+        Chat other = new Chat();
+        other.setId(UUID.randomUUID());
+        other.setUser(user);
+        when(chatRepository.findAllByUserIdOrderByUpdatedAtDesc(userId)).thenReturn(List.of(chat, other));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        chatService.deleteAllChats(userId);
+
+        verify(chatMemory).clear(chatId.toString());
+        verify(chatMemory).clear(other.getId().toString());
+        verify(chatRepository).deleteAll(List.of(chat, other));
+        assertNull(user.getUserContext());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void shouldThrowDeleteFailed_whenResetFails() {
+        when(chatRepository.findAllByUserIdOrderByUpdatedAtDesc(userId)).thenReturn(List.of(chat));
+        doThrow(new RuntimeException()).when(chatRepository).deleteAll(any());
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> chatService.deleteAllChats(userId));
 
         assertEquals(ErrorKey.CHAT_DELETE_FAILED, exception.getErrorKey());
     }


### PR DESCRIPTION
Two lighter agent requirements, backend side.

## Rename a chat
- `PUT /ai/agent/chats/{chatId}` → `ChatService.renameChat` (ownership-checked, `@NotBlank @Size(255)`, trimmed). Used PUT (not PATCH) because the shared frontend HttpClient only exposes get/post/put/delete.

## Reset the agent
- `DELETE /ai/agent/chats` → `ChatService.deleteAllChats`: deletes all the caller's chats (cascades `agent_message`), clears each Spring AI memory window, and wipes the cross-chat global `userContext`.
- **Scoped to the authenticated principal** — `userId` is server-derived (`authenticatedUser`), never a request param, so a user can only reset themselves (no IDOR).

## Tests (+8, suite 490 green)
- `ChatServiceUnitTest`: rename trim/ownership, reset clears memory + context, failure path.
- `AiAgentControllerTest`: rename ok / blank-reject, delete-all.
- `ChatServiceIntegrationTest` (real Postgres): one user's reset leaves another user's chats and remembered context untouched.